### PR TITLE
chore: default model to gpt-5.4-mini across all code paths

### DIFF
--- a/functions/research/index.js
+++ b/functions/research/index.js
@@ -418,7 +418,7 @@ export const handler = async (event) => {
   // Admin overrides — only honoured when _adminKey matches ADMIN_KEY env var
   const adminKey = process.env.ADMIN_KEY;
   const isAdmin  = adminKey && body._adminKey === adminKey;
-  const model     = (isAdmin && body._model)      ? body._model      : (process.env.OPENAI_MODEL ?? 'o4-mini');
+  const model     = (isAdmin && body._model)      ? body._model      : (process.env.OPENAI_MODEL ?? 'gpt-5.4-mini');
   const promptFile= (isAdmin && body._promptFile) ? body._promptFile : null;
 
   const baseUrl = (process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '');

--- a/server/SchoolScanner.Config.psm1
+++ b/server/SchoolScanner.Config.psm1
@@ -52,7 +52,7 @@ function Get-ResearchSettingsDefaults {
 
     return [ordered]@{
         provider = "openai_compatible"
-        model = "gpt-5-mini"
+        model = "gpt-5.4-mini"
         baseUrl = "https://api.openai.com/v1"
         responsesPath = "/responses"
         apiKeyRequired = $true

--- a/web/admin/index.html
+++ b/web/admin/index.html
@@ -148,9 +148,9 @@
       <div>
         <label style="margin-top:0;font-size:0.78rem;color:#666;">Model</label>
         <select class="v-model" data-idx="0">
-          <option value="gpt-5-mini">gpt-5-mini</option>
-          <option value="gpt-5.4-nano">gpt-5.4-nano</option>
           <option value="gpt-5.4-mini">gpt-5.4-mini</option>
+          <option value="gpt-5.4-nano">gpt-5.4-nano</option>
+          <option value="gpt-5-mini">gpt-5-mini</option>
           <option value="gpt-5.4">gpt-5.4</option>
           <option value="o4-mini">o4-mini</option>
           <option value="gpt-4.1-mini">gpt-4.1-mini</option>
@@ -181,9 +181,9 @@
       <div>
         <label style="margin-top:0;font-size:0.78rem;color:#666;">Model</label>
         <select class="v-model" data-idx="1" disabled>
-          <option value="gpt-5-mini">gpt-5-mini</option>
-          <option value="gpt-5.4-nano">gpt-5.4-nano</option>
           <option value="gpt-5.4-mini">gpt-5.4-mini</option>
+          <option value="gpt-5.4-nano">gpt-5.4-nano</option>
+          <option value="gpt-5-mini">gpt-5-mini</option>
           <option value="gpt-5.4">gpt-5.4</option>
           <option value="o4-mini">o4-mini</option>
           <option value="gpt-4.1-mini">gpt-4.1-mini</option>
@@ -214,9 +214,9 @@
       <div>
         <label style="margin-top:0;font-size:0.78rem;color:#666;">Model</label>
         <select class="v-model" data-idx="2" disabled>
-          <option value="gpt-5-mini">gpt-5-mini</option>
-          <option value="gpt-5.4-nano">gpt-5.4-nano</option>
           <option value="gpt-5.4-mini">gpt-5.4-mini</option>
+          <option value="gpt-5.4-nano">gpt-5.4-nano</option>
+          <option value="gpt-5-mini">gpt-5-mini</option>
           <option value="gpt-5.4">gpt-5.4</option>
           <option value="o4-mini">o4-mini</option>
           <option value="gpt-4.1-mini">gpt-4.1-mini</option>

--- a/web/admin/result.html
+++ b/web/admin/result.html
@@ -88,7 +88,7 @@
   const label     = params.get('label')      || 'Variant';
   const branch    = params.get('branch')     || '';
   const question  = params.get('question')   || '';
-  const model     = params.get('model')      || 'o4-mini';
+  const model     = params.get('model')      || 'gpt-5.4-mini';
   const promptFile= params.get('promptFile') || '';
   const adminKey  = params.get('adminKey')   || '';
 


### PR DESCRIPTION
## Summary

Changes the hardcoded fallback model from `o4-mini` / `gpt-5-mini` to `gpt-5.4-mini` everywhere.

## Changes

- `functions/research/index.js` — fallback when `OPENAI_MODEL` env var is unset: `o4-mini` → `gpt-5.4-mini`
- `server/SchoolScanner.Config.psm1` — PowerShell config defaults: `gpt-5-mini` → `gpt-5.4-mini`
- `web/admin/index.html` — admin panel dropdowns: `gpt-5.4-mini` moved to first position (default) in all three variant selects
- `web/admin/result.html` — admin result page default: `o4-mini` → `gpt-5.4-mini`

## Notes

- The deployed Lambda reads its model from SSM (`/schoolscanner/openai_model`) — not affected by this change
- The `env.json` already has `gpt-5.4-mini` set, so local dev is already using it

🤖 Generated with [Claude Code](https://claude.com/claude-code)