### PR TITLE
fix: A2 verdict when no sub-grades, B1 table format

### DIFF
--- a/functions/research/.md/prompt_branch_1_bc_v1.md
+++ b/functions/research/.md/prompt_branch_1_bc_v1.md
@@ -151,7 +151,28 @@ Never write this section as a single prose paragraph.
 
 **Parent View data is pre-fetched — it appears in the Ofsted section of the pre-fetched block under "Ofsted Parent View".** Use it directly. Do not search for it.
 
-**Reproduce the full Parent View table exactly as it appears in the pre-fetched block** (all rows, percentages, and any ⚠️ flags). Include the academic year in the heading or first line — e.g. "Parent View 2024/25 — 127 responses". Then add 2–3 sentences of commentary calling out any ⚠️ flagged rows explicitly.
+**The body MUST start with a markdown table** using `|` syntax. Reproduce every row and percentage exactly as it appears in the pre-fetched block — this is a data table, not prose. Include the academic year and response count in the heading. Example body format:
+
+```
+Parent View 2024/25 — 127 responses
+
+| Question | % agree or strongly agree |
+|---|---:|
+| Would recommend this school | 94% |
+| My child is happy here | 96% |
+| My child feels safe | 93% ⚠️ |
+| Pupils are well behaved | 89% |
+| Bullying dealt with well | 78% ⚠️ |
+| School communicates well | 91% |
+| Concerns dealt with properly | 85% |
+| Acts in child's best interests | 92% |
+| Right support to learn | 88% |
+| SEND support | 76% |
+```
+
+After the table, add 2–3 bullet points of commentary calling out any ⚠️ flagged rows.
+
+Never replace the table with a prose summary. The table IS the content.
 
 Thresholds (already applied in the pre-fetched table — ⚠️ rows are already marked):
 - Would recommend: below 80%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -3618,15 +3618,17 @@ export function renderPartA(school, flags = {}) {
         const RANK = { 'Outstanding': 4, 'Exceptional': 5, 'Good': 3, 'Requires Improvement': 2, 'Inadequate': 1 };
         const overallRank = RANK[ofsted.overall] ?? 3;
         const subGrades = [ofsted.qualityOfEducation, ofsted.behaviour, ofsted.personalDevelopment, ofsted.leadership, ofsted.sixth].filter(Boolean);
-        const weaker   = subGrades.filter(g => (RANK[g] ?? 3) < overallRank);
-        const standout = subGrades.filter(g => (RANK[g] ?? 3) > overallRank);
-        lines.push('');
-        if (weaker.length)
-          lines.push(`Verdict: overall ${ofsted.overall}, with weaker sub-grade${weaker.length > 1 ? 's' : ''} — ${weaker.join(', ')}.`);
-        else if (standout.length)
-          lines.push(`Verdict: a clean overall picture at ${ofsted.overall}; standout sub-grade${standout.length > 1 ? 's' : ''} — ${standout.join(', ')}.`);
-        else
-          lines.push(`Verdict: overall ${ofsted.overall} — all sub-grades at or near the same level.`);
+        if (subGrades.length) {
+          const weaker   = subGrades.filter(g => (RANK[g] ?? 3) < overallRank);
+          const standout = subGrades.filter(g => (RANK[g] ?? 3) > overallRank);
+          lines.push('');
+          if (weaker.length)
+            lines.push(`Verdict: overall ${ofsted.overall}, with weaker sub-grade${weaker.length > 1 ? 's' : ''} — ${weaker.join(', ')}.`);
+          else if (standout.length)
+            lines.push(`Verdict: a clean overall picture at ${ofsted.overall}; standout sub-grade${standout.length > 1 ? 's' : ''} — ${standout.join(', ')}.`);
+          else
+            lines.push(`Verdict: overall ${ofsted.overall} — all sub-grades at or near the same level.`);
+        }
       }
 
       body = lines.join('\n');


### PR DESCRIPTION
A2 no longer falsely claims sub-grades when none extracted. B1 now has an explicit table example to prevent the AI from paraphrasing as prose.