### PR TITLE
fix: remove 3-year pooled columns from KS2 tables

### DIFF
--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-28T16:00:16.650Z",
+    "capturedAt": "2026-04-29T19:38:58.624Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,14 +1123,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 137,
+      "totalTransactions": 169,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,230,000",
+      "medianAllTypes": "£1,250,000",
       "byType": {
-        "Flat / Maisonette": "£1,095,000",
+        "Flat / Maisonette": "£1,110,000",
         "Semi-detached": "£6,050,000",
         "Detached": "£4,850,000",
-        "Terraced": "£2,500,000"
+        "Terraced": "£2,625,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-28T16:00:05.171Z",
+    "capturedAt": "2026-04-29T19:38:47.863Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -35,6 +35,7 @@
     "post16": null,
     "safeguarding": null,
     "reportUrl": "https://files.ofsted.gov.uk/v1/file/50184328",
+    "gradedReportUrl": null,
     "parentViewUrl": "https://parentview.ofsted.gov.uk/parent-view-results/urn/102055",
     "pupilExperience": "Latymer School provides pupils with high-quality education. Pupils are supported to  aim high and achieve well academically in most subjects. Leaders have high  expectations of pupils’ learning and how pupils should conduct themselves. Pupils  have a strong work ethic and show commitment to their learning. They attend  school extremely well. \n \nPupils feel safe, are well cared for and happy at school. Pupils of all ages get on well  with each other. Leaders ensure that all pupils are treated equally. Pupils are polite  and respectful. They behave well and want to learn. Bullying is rare but when it  happens, staff deal with it quickly. \n \nPupils enjoy school life and play an active role. They take full advantage of the  extensive range of societies and clubs on offer. These include plentif",
     "nextSteps": "-  In Years 7 to 11, leaders’ curriculum thinking in a few subjects is developing  further. Although leaders have defined which concepts should be taught,  consideration has not been given to the order that these concepts should be  taught and revisited. Where this is the case, leaders should strengthen the  curriculum by ensuring that subject knowledge is taught sequentially and pupils’  understanding of essential knowledge deepens over time. \n-  Occasionally, in Years 7 to 11, teachers do not check pupils’ understanding of  previous learning carefully. This means that misconceptions are not identified and  addressed in a timely way. Leaders should ensure that staff implement the  assessment policy across the curriculum consistently and as intended.",
@@ -3686,12 +3687,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 140,
+      "totalTransactions": 113,
       "postcodesQueried": 100,
-      "medianAllTypes": "£430,000",
+      "medianAllTypes": "£422,500",
       "byType": {
-        "Terraced": "£435,000",
-        "Flat / Maisonette": "£240,000",
+        "Terraced": "£430,000",
+        "Flat / Maisonette": "£222,500",
         "Semi-detached": "£470,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-28T15:59:29.695Z",
+    "capturedAt": "2026-04-29T19:38:14.024Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -20,7 +20,7 @@
   },
   "ofsted": {
     "overall": "Good",
-    "date": "12 March 2024",
+    "date": "21 May 2014",
     "qualityOfEducation": null,
     "behaviour": null,
     "personalDevelopment": null,
@@ -35,6 +35,7 @@
     "post16": null,
     "safeguarding": null,
     "reportUrl": "https://files.ofsted.gov.uk/v1/file/50246525",
+    "gradedReportUrl": "https://files.ofsted.gov.uk/v1/file/2394729",
     "parentViewUrl": "https://parentview.ofsted.gov.uk/parent-view-results/urn/124987",
     "pupilExperience": "Pupils eagerly anticipate coming to this school. Sights are set high for pupils, and they  achieve well. They get a great start to their education in the Nursery, where adults  skilfully teach the curriculum with children’s interests in mind. Children quickly develop a  thirst for learning, fascinated by the captivating lessons and wider experiences their  teachers plan for them. They visit art galleries and museums and are inspired to find out  more about great artists and scientists. \n \nPupils are taught how to recognise their emotions and ways of staying calm such as  listening to music, peer massage or controlling their breathing. They know they can trust  adults to help them by talking openly about feelings of anger or sadness. As a result,  pupils live up to the school’s high expecta",
     "nextSteps": "-  In some areas of the curriculum, the most important knowledge that pupils need to  know is not yet fully defined. As a result, pupils’ learning does not always build as",
@@ -297,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 307,
+      "totalTransactions": 273,
       "postcodesQueried": 100,
-      "medianAllTypes": "£430,000",
+      "medianAllTypes": "£422,500",
       "byType": {
         "Semi-detached": "£500,000",
-        "Terraced": "£400,000",
-        "Flat / Maisonette": "£235,000",
-        "Detached": "£560,000"
+        "Terraced": "£405,000",
+        "Flat / Maisonette": "£250,000",
+        "Detached": "£575,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-28T15:59:37.255Z",
+    "capturedAt": "2026-04-29T19:38:21.623Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -35,6 +35,7 @@
     "post16": null,
     "safeguarding": null,
     "reportUrl": "https://files.ofsted.gov.uk/v1/file/50235645",
+    "gradedReportUrl": null,
     "parentViewUrl": "https://parentview.ofsted.gov.uk/parent-view-results/urn/125068",
     "pupilExperience": "‘A place to learn together’ is very much pupils’ experience at Earlswood Junior \nSchool. Pupils value the broad and ambitious curriculum they are offered, which is  enhanced through specialist teachers in music and physical education (PE). The  school has high expectations for all pupils, including pupils with special educational  needs and/or disabilities (SEND). As a result, the majority of pupils are achieving  well. \n \nPupils behave well here. They know what is expected of them. This is underpinned  by the ‘SMILE’ behaviours of self-regulation, manners, independence, listening with  respect and empathy. Pupils fully understand these and learn about them weekly. \nPupils feel safe, including from bullying. \n \nThe school provides a range of enrichment and leadership opportunities for pupi",
     "nextSteps": "-  The task design in some curriculum subjects does not support all pupils to move  swiftly on in their learning or develop a really deep understanding. This means  that some pupils do not always achieve as highly as they could. The school needs  to provide suitable tasks across all subjects that support all pupils to make the  most progress possible.",
@@ -917,14 +918,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 421,
+      "totalTransactions": 302,
       "postcodesQueried": 100,
-      "medianAllTypes": "£452,500",
+      "medianAllTypes": "£430,000",
       "byType": {
-        "Semi-detached": "£515,000",
-        "Terraced": "£422,500",
-        "Detached": "£575,000",
-        "Flat / Maisonette": "£260,000"
+        "Semi-detached": "£523,750",
+        "Terraced": "£400,000",
+        "Detached": "£780,000",
+        "Flat / Maisonette": "£255,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-28T16:00:09.590Z",
+    "capturedAt": "2026-04-29T19:38:51.720Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,14 +170,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 167,
+      "totalTransactions": 164,
       "postcodesQueried": 100,
-      "medianAllTypes": "£348,000",
+      "medianAllTypes": "£346,000",
       "byType": {
         "Flat / Maisonette": "£290,000",
-        "Terraced": "£580,000",
-        "Detached": "£1,040,000",
-        "Semi-detached": "£760,000"
+        "Terraced": "£603,000",
+        "Detached": "£1,150,000",
+        "Semi-detached": "£770,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-28T16:00:13.190Z",
+    "capturedAt": "2026-04-29T19:38:55.177Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,14 +1110,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 178,
+      "totalTransactions": 99,
       "postcodesQueried": 74,
-      "medianAllTypes": "£650,000",
+      "medianAllTypes": "£440,000",
       "byType": {
-        "Flat / Maisonette": "£315,000",
-        "Detached": "£988,000",
-        "Semi-detached": "£688,500",
-        "Terraced": "£625,000"
+        "Flat / Maisonette": "£312,500",
+        "Detached": "£880,000",
+        "Semi-detached": "£699,950"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-28T15:59:45.017Z",
+    "capturedAt": "2026-04-29T19:38:29.268Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -35,6 +35,7 @@
     "post16": null,
     "safeguarding": null,
     "reportUrl": "https://files.ofsted.gov.uk/v1/file/50238234",
+    "gradedReportUrl": null,
     "parentViewUrl": "https://parentview.ofsted.gov.uk/parent-view-results/urn/137648",
     "pupilExperience": "Pupils are happy at this school. They are proud to share their learning and show  excitement when they talk about their school community. The school has high  expectations for all pupils. Pupils enjoy an exciting curriculum which embraces the  heritage of the community. For example, pupils get to learn about the importance of  the Docklands through London’s history. Pupils clearly value where they live and the  diversity that exists within the school community. Pupils demonstrate excellent  attitudes to learning and achieve well. \n \nInnovative ideas for playtimes create a joyful, happy environment. For example,  pupils enjoy dressing up, role play and an exciting range of games. Pupils respect  and value each other. Staff and pupils share positive and warm working  relationships. Pupils fe",
     "nextSteps": "The school’s curriculum is ambitious and carefully sequenced. It allows pupils to  build up their knowledge, skills and use of vocabulary over time. Children in the  early years receive a strong foundation to their school life. The stimulating learning  environment encourages children to be curious about their learning. Children focus  for sustained periods and show resilience in their problem-solving. For instance,  children in the Nursery worked together impressively to find the right building blocks  for a tower they were constructing. \n \nLeaders make sure that staff have the support and training they need to enable all  pupils to access the curriculum and learn well. Staff are highly skilled at identifying  and meeting pupils’ needs, including those with SEND. Throughout the school, staff  use a range of approaches consistently to support pupils’ learning. For example,  staff use different communication systems which enable all pupils to share their  answers, points of view and emotions. \n \nStaff present information clearly to pupils. They provide pupils with different  opportunities to show what they know. For example, in mathematics, some pupils  used practical resources to show the answers to their calculations while others  recorded these in their workbooks.",
@@ -980,13 +981,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 269,
+      "totalTransactions": 218,
       "postcodesQueried": 100,
-      "medianAllTypes": "£500,000",
+      "medianAllTypes": "£525,000",
       "byType": {
-        "Flat / Maisonette": "£450,000",
-        "Terraced": "£700,000",
-        "Semi-detached": "£675,000"
+        "Flat / Maisonette": "£480,000",
+        "Terraced": "£708,000",
+        "Semi-detached": "£730,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-28T15:59:58.565Z",
+    "capturedAt": "2026-04-29T19:38:42.891Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-28T15:59:49.126Z",
+    "capturedAt": "2026-04-29T19:38:33.606Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -35,6 +35,7 @@
     "post16": null,
     "safeguarding": null,
     "reportUrl": "https://files.ofsted.gov.uk/v1/file/50238758",
+    "gradedReportUrl": null,
     "parentViewUrl": "https://parentview.ofsted.gov.uk/parent-view-results/urn/145217",
     "pupilExperience": "This is a welcoming and inclusive school. The school’s values of ‘respect, curiosity,  resilience, friendship and kindness’ are being realised. Staff want the best for pupils. \nThey have very warm relationships with pupils and know them well. Pupils enjoy  coming to school and they are very proud of it. They get on very well with each  other and with staff. Leaders prioritise ensuring that Year 7 pupils settle in quickly  when they join the school. \n \nPupils’ conduct is excellent in lessons and around the school. Pupils are very clear  about the school’s expectations for behaviour. They settle to their work quickly and  are eager to learn. Parents and carers and pupils praise the school’s very high  quality of pastoral care. Pupils are well cared for. There is always somebody in the  schoo",
     "nextSteps": "-  Lessons are not always adapted successfully to meet the needs of all pupils. This  means that not all pupils achieve highly, particularly the most disadvantaged. The  school should ensure that it keeps careful oversight of how well the curriculum is  being implemented and provides support so that it is of a consistently high  standard in all subjects. \n-  Plans to improve reading across the whole school have only recently been put in  place. As a result, many pupils who read below the expected level for their  chronological reading age are not able to read well enough to access the full  curriculum. The school needs to ensure that the new approaches to reading are  securely and consistently embedded and have the planned impact.",
@@ -1926,14 +1927,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 256,
+      "totalTransactions": 231,
       "postcodesQueried": 100,
-      "medianAllTypes": "£455,000",
+      "medianAllTypes": "£450,000",
       "byType": {
-        "Semi-detached": "£476,000",
+        "Semi-detached": "£475,000",
         "Terraced": "£445,000",
         "Flat / Maisonette": "£250,000",
-        "Detached": "£805,000"
+        "Detached": "£800,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-28T16:00:16.652Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-29T19:38:58.625Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -273,7 +273,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 137 sales, 5yr): median £1,230,000 · by type: Flat / Maisonette £1,095,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £2,500,000
+- House prices (~800m, 169 sales, 5yr): median £1,250,000 · by type: Flat / Maisonette £1,110,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £2,625,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-28T16:00:05.174Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-29T19:38:47.864Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -788,7 +788,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 140 sales, 5yr): median £430,000 · by type: Terraced £435,000, Flat / Maisonette £240,000, Semi-detached £470,000
+- House prices (~800m, 113 sales, 5yr): median £422,500 · by type: Terraced £430,000, Flat / Maisonette £222,500, Semi-detached £470,000
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-28T15:59:29.696Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-29T19:38:14.025Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -50,7 +50,7 @@
 - Teaching and Teaching support staff: £4,531/pupil | avg £4,891/pupil | £359 less than avg | -7%
 
 ### Inspection Outcomes (Ofsted)
-- Overall: **Good** (12 March 2024)
+- Overall: **Good** (21 May 2014)
 - Parent View: https://parentview.ofsted.gov.uk/parent-view-results/urn/124987 _(data not retrieved)_
 
 **What it's like to be a pupil**
@@ -67,7 +67,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 307 sales, 5yr): median £430,000 · by type: Semi-detached £500,000, Terraced £400,000, Flat / Maisonette £235,000, Detached £560,000
+- House prices (~800m, 273 sales, 5yr): median £422,500 · by type: Semi-detached £500,000, Terraced £405,000, Flat / Maisonette £250,000, Detached £575,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-28T15:59:37.257Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-29T19:38:21.624Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -45,31 +45,31 @@
 | Maths | 0.0 | average | -1.1 to 1.1 |
 
 **Results over time**
-| Eligible cohort | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 118 | 110 | 105 | 333 |
+| Eligible cohort | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 118 | 110 | 105 |
 
-| Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 73% | 66% | 74% | 71% |
+| Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 73% | 66% | 74% |
 | Local authority | — | — | 66% | — |
 | England | 60% | 61% | 61% | — |
 
-| Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 10% | 12% | 15% | 12% |
+| Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 10% | 12% | 15% |
 | Local authority | — | — | 11% | — |
 | England | 8% | 8% | 9% | — |
 
-| Reading — average score | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 108 | 108 | 109 | 108 |
+| Reading — average score | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 108 | 108 | 109 |
 | Local authority | — | — | 107 | — |
 | England | 105 | 105 | 106 | — |
 
-| Maths — average score | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 106 | 105 | 106 | 106 |
+| Maths — average score | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 106 | 105 | 106 |
 | Local authority | — | — | 106 | — |
 | England | 104 | 104 | 105 | — |
 
@@ -273,7 +273,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 421 sales, 5yr): median £452,500 · by type: Semi-detached £515,000, Terraced £422,500, Detached £575,000, Flat / Maisonette £260,000
+- House prices (~800m, 302 sales, 5yr): median £430,000 · by type: Semi-detached £523,750, Terraced £400,000, Detached £780,000, Flat / Maisonette £255,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-28T16:00:09.593Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-29T19:38:51.721Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -68,7 +68,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 167 sales, 5yr): median £348,000 · by type: Flat / Maisonette £290,000, Terraced £580,000, Detached £1,040,000, Semi-detached £760,000
+- House prices (~800m, 164 sales, 5yr): median £346,000 · by type: Flat / Maisonette £290,000, Terraced £603,000, Detached £1,150,000, Semi-detached £770,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-28T16:00:13.192Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-29T19:38:55.178Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -283,7 +283,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 178 sales, 5yr): median £650,000 · by type: Flat / Maisonette £315,000, Detached £988,000, Semi-detached £688,500, Terraced £625,000
+- House prices (~800m, 99 sales, 5yr): median £440,000 · by type: Flat / Maisonette £312,500, Detached £880,000, Semi-detached £699,950
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-28T15:59:45.019Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-29T19:38:29.269Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -45,31 +45,31 @@
 | Maths | 3.8 | well above | 2.4 to 5.1 |
 
 **Results over time**
-| Eligible cohort | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 77 | 76 | 74 | 227 |
+| Eligible cohort | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 77 | 76 | 74 |
 
-| Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 73% | 87% | 89% | 83% |
+| Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 73% | 87% | 89% |
 | Local authority | — | — | 70% | — |
 | England | 60% | 61% | 61% | — |
 
-| Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 19% | 34% | 28% | 27% |
+| Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 19% | 34% | 28% |
 | Local authority | — | — | 12% | — |
 | England | 8% | 8% | 9% | — |
 
-| Reading — average score | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 107 | 111 | 110 | 109 |
+| Reading — average score | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 107 | 111 | 110 |
 | Local authority | — | — | 107 | — |
 | England | 105 | 105 | 106 | — |
 
-| Maths — average score | 2023 | 2024 | 2025 | 3-yr pooled |
-|---|---:|---:|---:|---:|
-| School | 108 | 110 | 109 | 109 |
+| Maths — average score | 2023 | 2024 | 2025 |
+|---|---:|---:|---:|
+| School | 108 | 110 | 109 |
 | Local authority | — | — | 106 | — |
 | England | 104 | 104 | 105 | — |
 
@@ -292,7 +292,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 269 sales, 5yr): median £500,000 · by type: Flat / Maisonette £450,000, Terraced £700,000, Semi-detached £675,000
+- House prices (~800m, 218 sales, 5yr): median £525,000 · by type: Flat / Maisonette £480,000, Terraced £708,000, Semi-detached £730,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-28T15:59:58.567Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-29T19:38:42.892Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-28T15:59:49.128Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-29T19:38:33.607Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -414,7 +414,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 256 sales, 5yr): median £455,000 · by type: Semi-detached £476,000, Terraced £445,000, Flat / Maisonette £250,000, Detached £805,000
+- House prices (~800m, 231 sales, 5yr): median £450,000 · by type: Semi-detached £475,000, Terraced £445,000, Flat / Maisonette £250,000, Detached £800,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -2506,11 +2506,6 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     const read23 = v('READ_AVERAGE_23'); const read24 = v('READ_AVERAGE_24');
     const mat23  = v('MAT_AVERAGE_23');  const mat24  = v('MAT_AVERAGE_24');
     const cohort23 = v('TELIG_23');      const cohort24 = v('TELIG_24');
-    const cohort3yr = v('TELIG_3YR');
-
-    // ── 3-year pooled (small-cohort context)
-    const rwm3yr   = v('PTRWM_EXP_3YR');  const rwmH3yr  = v('PTRWM_HIGH_3YR');
-    const read3yr  = v('READ_AVERAGE_3YR'); const mat3yr  = v('MAT_AVERAGE_3YR');
 
     if (rwm || read || mat) {
       const nat = NATIONAL_AVG.KS2;
@@ -2592,7 +2587,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
       }
 
       // ── Table 4: Results over time ────────────────────────────────────────
-      // School: 3-year data from DfE CSV (_23/_24 suffixes) + 3-year pooled column
+      // School: 3-year data from DfE CSV (_23/_24 suffixes)
       // LA: current year from EES API; historical not yet fetched (shown as —)
       // England: hardcoded from DfE national tables
       // Source: https://explore-education-statistics.service.gov.uk/find-statistics/key-stage-2-attainment
@@ -2607,41 +2602,41 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
 
         // Cohort sizes (provides denominator context for all trend metrics)
         if (cohort23 || cohort24 || cohort) {
-          lines.push('| Eligible cohort | 2023 | 2024 | 2025 | 3-yr pooled |');
-          lines.push('|---|---:|---:|---:|---:|');
-          lines.push(`| School | ${c(cohort23)} | ${c(cohort24)} | ${c(cohort)} | ${c(cohort3yr)} |`);
+          lines.push('| Eligible cohort | 2023 | 2024 | 2025 |');
+          lines.push('|---|---:|---:|---:|');
+          lines.push(`| School | ${c(cohort23)} | ${c(cohort24)} | ${c(cohort)} |`);
           lines.push('');
         }
 
-        lines.push('| Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 | 3-yr pooled |');
-        lines.push('|---|---:|---:|---:|---:|');
-        lines.push(`| School | ${c(rwm23)} | ${c(rwm24)} | ${c(rwm)} | ${c(rwm3yr)} |`);
+        lines.push('| Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 |');
+        lines.push('|---|---:|---:|---:|');
+        lines.push(`| School | ${c(rwm23)} | ${c(rwm24)} | ${c(rwm)} |`);
         lines.push(`| Local authority | — | — | ${la('rwm','expected')} | — |`);
         lines.push(`| England | ${NAT_HIST['2023'].rwmExp}% | ${NAT_HIST['2024'].rwmExp}% | ${NAT_HIST['2025'].rwmExp}% | — |`);
         lines.push('');
 
         if (rwmH23 || rwmH24 || rwmH) {
-          lines.push('| Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 | 3-yr pooled |');
-          lines.push('|---|---:|---:|---:|---:|');
-          lines.push(`| School | ${c(rwmH23)} | ${c(rwmH24)} | ${c(rwmH)} | ${c(rwmH3yr)} |`);
+          lines.push('| Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 |');
+          lines.push('|---|---:|---:|---:|');
+          lines.push(`| School | ${c(rwmH23)} | ${c(rwmH24)} | ${c(rwmH)} |`);
           lines.push(`| Local authority | — | — | ${la('rwm','higher')} | — |`);
           lines.push(`| England | ${NAT_HIST['2023'].rwmHigh}% | ${NAT_HIST['2024'].rwmHigh}% | ${NAT_HIST['2025'].rwmHigh}% | — |`);
           lines.push('');
         }
 
         if (read23 || read24 || readSc) {
-          lines.push('| Reading — average score | 2023 | 2024 | 2025 | 3-yr pooled |');
-          lines.push('|---|---:|---:|---:|---:|');
-          lines.push(`| School | ${c(read23)} | ${c(read24)} | ${c(readSc)} | ${c(read3yr)} |`);
+          lines.push('| Reading — average score | 2023 | 2024 | 2025 |');
+          lines.push('|---|---:|---:|---:|');
+          lines.push(`| School | ${c(read23)} | ${c(read24)} | ${c(readSc)} |`);
           lines.push(`| Local authority | — | — | ${laS('reading')} | — |`);
           lines.push(`| England | ${NAT_HIST['2023'].readAvg} | ${NAT_HIST['2024'].readAvg} | ${NAT_HIST['2025'].readAvg} | — |`);
           lines.push('');
         }
 
         if (mat23 || mat24 || matSc) {
-          lines.push('| Maths — average score | 2023 | 2024 | 2025 | 3-yr pooled |');
-          lines.push('|---|---:|---:|---:|---:|');
-          lines.push(`| School | ${c(mat23)} | ${c(mat24)} | ${c(matSc)} | ${c(mat3yr)} |`);
+          lines.push('| Maths — average score | 2023 | 2024 | 2025 |');
+          lines.push('|---|---:|---:|---:|');
+          lines.push(`| School | ${c(mat23)} | ${c(mat24)} | ${c(matSc)} |`);
           lines.push(`| Local authority | — | — | ${laS('maths')} | — |`);
           lines.push(`| England | ${NAT_HIST['2023'].matAvg} | ${NAT_HIST['2024'].matAvg} | ${NAT_HIST['2025'].matAvg} | — |`);
           lines.push('');


### PR DESCRIPTION
Removed 3-yr pooled column from all KS2 performance tables. Retains year-over-year columns.