### PR TITLE
fix: remove 3-yr pooled columns, consistent table widths

### DIFF
--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-29T19:38:58.624Z",
+    "capturedAt": "2026-04-29T19:52:19.879Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,14 +1123,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 169,
+      "totalTransactions": 101,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,250,000",
+      "medianAllTypes": "£1,320,000",
       "byType": {
-        "Flat / Maisonette": "£1,110,000",
+        "Flat / Maisonette": "£1,095,000",
         "Semi-detached": "£6,050,000",
         "Detached": "£4,850,000",
-        "Terraced": "£2,625,000"
+        "Terraced": "£1,300,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-29T19:38:47.863Z",
+    "capturedAt": "2026-04-29T19:52:09.517Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 113,
+      "totalTransactions": 55,
       "postcodesQueried": 100,
-      "medianAllTypes": "£422,500",
+      "medianAllTypes": "£432,000",
       "byType": {
-        "Terraced": "£430,000",
-        "Flat / Maisonette": "£222,500",
-        "Semi-detached": "£470,000"
+        "Terraced": "£435,000",
+        "Semi-detached": "£475,000",
+        "Flat / Maisonette": "£269,950"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-29T19:38:14.024Z",
+    "capturedAt": "2026-04-29T19:51:34.827Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 273,
+      "totalTransactions": 251,
       "postcodesQueried": 100,
-      "medianAllTypes": "£422,500",
+      "medianAllTypes": "£435,000",
       "byType": {
-        "Semi-detached": "£500,000",
+        "Semi-detached": "£485,000",
         "Terraced": "£405,000",
-        "Flat / Maisonette": "£250,000",
-        "Detached": "£575,000"
+        "Flat / Maisonette": "£267,000",
+        "Detached": "£550,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-29T19:38:21.623Z",
+    "capturedAt": "2026-04-29T19:51:42.306Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,14 +918,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 302,
+      "totalTransactions": 213,
       "postcodesQueried": 100,
-      "medianAllTypes": "£430,000",
+      "medianAllTypes": "£425,000",
       "byType": {
-        "Semi-detached": "£523,750",
-        "Terraced": "£400,000",
-        "Detached": "£780,000",
-        "Flat / Maisonette": "£255,000"
+        "Semi-detached": "£450,000",
+        "Terraced": "£423,000",
+        "Detached": "£555,000",
+        "Flat / Maisonette": "£260,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-29T19:38:51.720Z",
+    "capturedAt": "2026-04-29T19:52:13.006Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,14 +170,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 164,
+      "totalTransactions": 179,
       "postcodesQueried": 100,
-      "medianAllTypes": "£346,000",
+      "medianAllTypes": "£355,000",
       "byType": {
         "Flat / Maisonette": "£290,000",
-        "Terraced": "£603,000",
-        "Detached": "£1,150,000",
-        "Semi-detached": "£770,000"
+        "Terraced": "£570,000",
+        "Detached": "£1,040,000",
+        "Semi-detached": "£840,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-29T19:38:55.177Z",
+    "capturedAt": "2026-04-29T19:52:16.516Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,13 +1110,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 99,
+      "totalTransactions": 144,
       "postcodesQueried": 74,
-      "medianAllTypes": "£440,000",
+      "medianAllTypes": "£688,500",
       "byType": {
         "Flat / Maisonette": "£312,500",
-        "Detached": "£880,000",
-        "Semi-detached": "£699,950"
+        "Detached": "£985,000",
+        "Semi-detached": "£699,950",
+        "Terraced": "£625,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-29T19:38:29.268Z",
+    "capturedAt": "2026-04-29T19:51:50.949Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,13 +981,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 218,
+      "totalTransactions": 230,
       "postcodesQueried": 100,
-      "medianAllTypes": "£525,000",
+      "medianAllTypes": "£526,500",
       "byType": {
         "Flat / Maisonette": "£480,000",
-        "Terraced": "£708,000",
-        "Semi-detached": "£730,000"
+        "Terraced": "£650,000",
+        "Semi-detached": "£665,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-29T19:38:42.891Z",
+    "capturedAt": "2026-04-29T19:52:05.602Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-29T19:38:33.606Z",
+    "capturedAt": "2026-04-29T19:51:56.241Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,14 +1927,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 231,
+      "totalTransactions": 220,
       "postcodesQueried": 100,
-      "medianAllTypes": "£450,000",
+      "medianAllTypes": "£455,000",
       "byType": {
-        "Semi-detached": "£475,000",
-        "Terraced": "£445,000",
-        "Flat / Maisonette": "£250,000",
-        "Detached": "£800,000"
+        "Semi-detached": "£476,000",
+        "Terraced": "£440,000",
+        "Flat / Maisonette": "£280,000",
+        "Detached": "£810,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-29T19:38:58.625Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-29T19:52:19.880Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -273,7 +273,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 169 sales, 5yr): median £1,250,000 · by type: Flat / Maisonette £1,110,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £2,625,000
+- House prices (~800m, 101 sales, 5yr): median £1,320,000 · by type: Flat / Maisonette £1,095,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £1,300,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-29T19:38:47.864Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-29T19:52:09.518Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -788,7 +788,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 113 sales, 5yr): median £422,500 · by type: Terraced £430,000, Flat / Maisonette £222,500, Semi-detached £470,000
+- House prices (~800m, 55 sales, 5yr): median £432,000 · by type: Terraced £435,000, Semi-detached £475,000, Flat / Maisonette £269,950
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-29T19:38:14.025Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-29T19:51:34.828Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -67,7 +67,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 273 sales, 5yr): median £422,500 · by type: Semi-detached £500,000, Terraced £405,000, Flat / Maisonette £250,000, Detached £575,000
+- House prices (~800m, 251 sales, 5yr): median £435,000 · by type: Semi-detached £485,000, Terraced £405,000, Flat / Maisonette £267,000, Detached £550,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-29T19:38:21.624Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-29T19:51:42.308Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -52,26 +52,26 @@
 | Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 73% | 66% | 74% |
-| Local authority | — | — | 66% | — |
-| England | 60% | 61% | 61% | — |
+| Local authority | — | — | 66% |
+| England | 60% | 61% | 61% |
 
 | Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 10% | 12% | 15% |
-| Local authority | — | — | 11% | — |
-| England | 8% | 8% | 9% | — |
+| Local authority | — | — | 11% |
+| England | 8% | 8% | 9% |
 
 | Reading — average score | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 108 | 108 | 109 |
-| Local authority | — | — | 107 | — |
-| England | 105 | 105 | 106 | — |
+| Local authority | — | — | 107 |
+| England | 105 | 105 | 106 |
 
 | Maths — average score | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 106 | 105 | 106 |
-| Local authority | — | — | 106 | — |
-| England | 104 | 104 | 105 | — |
+| Local authority | — | — | 106 |
+| England | 104 | 104 | 105 |
 
 | Special Educational Needs within Key Stage 2 cohort | Count | % of cohort |
 |---|---:|---:|
@@ -273,7 +273,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 302 sales, 5yr): median £430,000 · by type: Semi-detached £523,750, Terraced £400,000, Detached £780,000, Flat / Maisonette £255,000
+- House prices (~800m, 213 sales, 5yr): median £425,000 · by type: Semi-detached £450,000, Terraced £423,000, Detached £555,000, Flat / Maisonette £260,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-29T19:38:51.721Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-29T19:52:13.007Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -68,7 +68,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 164 sales, 5yr): median £346,000 · by type: Flat / Maisonette £290,000, Terraced £603,000, Detached £1,150,000, Semi-detached £770,000
+- House prices (~800m, 179 sales, 5yr): median £355,000 · by type: Flat / Maisonette £290,000, Terraced £570,000, Detached £1,040,000, Semi-detached £840,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-29T19:38:55.178Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-29T19:52:16.517Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -283,7 +283,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 99 sales, 5yr): median £440,000 · by type: Flat / Maisonette £312,500, Detached £880,000, Semi-detached £699,950
+- House prices (~800m, 144 sales, 5yr): median £688,500 · by type: Flat / Maisonette £312,500, Detached £985,000, Semi-detached £699,950, Terraced £625,000
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-29T19:38:29.269Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-29T19:51:50.950Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -52,26 +52,26 @@
 | Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 73% | 87% | 89% |
-| Local authority | — | — | 70% | — |
-| England | 60% | 61% | 61% | — |
+| Local authority | — | — | 70% |
+| England | 60% | 61% | 61% |
 
 | Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 19% | 34% | 28% |
-| Local authority | — | — | 12% | — |
-| England | 8% | 8% | 9% | — |
+| Local authority | — | — | 12% |
+| England | 8% | 8% | 9% |
 
 | Reading — average score | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 107 | 111 | 110 |
-| Local authority | — | — | 107 | — |
-| England | 105 | 105 | 106 | — |
+| Local authority | — | — | 107 |
+| England | 105 | 105 | 106 |
 
 | Maths — average score | 2023 | 2024 | 2025 |
 |---|---:|---:|---:|
 | School | 108 | 110 | 109 |
-| Local authority | — | — | 106 | — |
-| England | 104 | 104 | 105 | — |
+| Local authority | — | — | 106 |
+| England | 104 | 104 | 105 |
 
 | Special Educational Needs within Key Stage 2 cohort | Count | % of cohort |
 |---|---:|---:|
@@ -292,7 +292,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 218 sales, 5yr): median £525,000 · by type: Flat / Maisonette £480,000, Terraced £708,000, Semi-detached £730,000
+- House prices (~800m, 230 sales, 5yr): median £526,500 · by type: Flat / Maisonette £480,000, Terraced £650,000, Semi-detached £665,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-29T19:38:42.892Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-29T19:52:05.603Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-29T19:38:33.607Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-29T19:51:56.242Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -414,7 +414,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 231 sales, 5yr): median £450,000 · by type: Semi-detached £475,000, Terraced £445,000, Flat / Maisonette £250,000, Detached £800,000
+- House prices (~800m, 220 sales, 5yr): median £455,000 · by type: Semi-detached £476,000, Terraced £440,000, Flat / Maisonette £280,000, Detached £810,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -2611,16 +2611,16 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
         lines.push('| Reading, Writing and Maths — % meeting expected standard | 2023 | 2024 | 2025 |');
         lines.push('|---|---:|---:|---:|');
         lines.push(`| School | ${c(rwm23)} | ${c(rwm24)} | ${c(rwm)} |`);
-        lines.push(`| Local authority | — | — | ${la('rwm','expected')} | — |`);
-        lines.push(`| England | ${NAT_HIST['2023'].rwmExp}% | ${NAT_HIST['2024'].rwmExp}% | ${NAT_HIST['2025'].rwmExp}% | — |`);
+        lines.push(`| Local authority | — | — | ${la('rwm','expected')} |`);
+        lines.push(`| England | ${NAT_HIST['2023'].rwmExp}% | ${NAT_HIST['2024'].rwmExp}% | ${NAT_HIST['2025'].rwmExp}% |`);
         lines.push('');
 
         if (rwmH23 || rwmH24 || rwmH) {
           lines.push('| Reading, Writing and Maths — % achieving higher standard | 2023 | 2024 | 2025 |');
           lines.push('|---|---:|---:|---:|');
           lines.push(`| School | ${c(rwmH23)} | ${c(rwmH24)} | ${c(rwmH)} |`);
-          lines.push(`| Local authority | — | — | ${la('rwm','higher')} | — |`);
-          lines.push(`| England | ${NAT_HIST['2023'].rwmHigh}% | ${NAT_HIST['2024'].rwmHigh}% | ${NAT_HIST['2025'].rwmHigh}% | — |`);
+          lines.push(`| Local authority | — | — | ${la('rwm','higher')} |`);
+          lines.push(`| England | ${NAT_HIST['2023'].rwmHigh}% | ${NAT_HIST['2024'].rwmHigh}% | ${NAT_HIST['2025'].rwmHigh}% |`);
           lines.push('');
         }
 
@@ -2628,8 +2628,8 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
           lines.push('| Reading — average score | 2023 | 2024 | 2025 |');
           lines.push('|---|---:|---:|---:|');
           lines.push(`| School | ${c(read23)} | ${c(read24)} | ${c(readSc)} |`);
-          lines.push(`| Local authority | — | — | ${laS('reading')} | — |`);
-          lines.push(`| England | ${NAT_HIST['2023'].readAvg} | ${NAT_HIST['2024'].readAvg} | ${NAT_HIST['2025'].readAvg} | — |`);
+          lines.push(`| Local authority | — | — | ${laS('reading')} |`);
+          lines.push(`| England | ${NAT_HIST['2023'].readAvg} | ${NAT_HIST['2024'].readAvg} | ${NAT_HIST['2025'].readAvg} |`);
           lines.push('');
         }
 
@@ -2637,8 +2637,8 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
           lines.push('| Maths — average score | 2023 | 2024 | 2025 |');
           lines.push('|---|---:|---:|---:|');
           lines.push(`| School | ${c(mat23)} | ${c(mat24)} | ${c(matSc)} |`);
-          lines.push(`| Local authority | — | — | ${laS('maths')} | — |`);
-          lines.push(`| England | ${NAT_HIST['2023'].matAvg} | ${NAT_HIST['2024'].matAvg} | ${NAT_HIST['2025'].matAvg} | — |`);
+          lines.push(`| Local authority | — | — | ${laS('maths')} |`);
+          lines.push(`| England | ${NAT_HIST['2023'].matAvg} | ${NAT_HIST['2024'].matAvg} | ${NAT_HIST['2025'].matAvg} |`);
           lines.push('');
         }
       }

--- a/web/app.js
+++ b/web/app.js
@@ -178,14 +178,15 @@
 
   function renderTable(container, tableLines) {
     var table = document.createElement("table");
-    table.className = "md-table";
     var headerCells = null;
     var tbody = null;
+    var colCount = 0;
 
     tableLines.forEach(function (line, i) {
       if (isTableSeparator(line)) return;
       var cells = parseTableRow(line);
       if (i === 0) {
+        colCount = cells.length;
         var thead = document.createElement("thead");
         var tr = document.createElement("tr");
         cells.forEach(function (cell) {
@@ -207,6 +208,7 @@
         tbody.appendChild(tr);
       }
     });
+    table.className = "md-table cols-" + colCount;
     var scroll = document.createElement("div");
     scroll.className = "table-scroll";
     scroll.appendChild(table);

--- a/web/styles.css
+++ b/web/styles.css
@@ -471,7 +471,30 @@ input[type="email"]:focus,
   border-collapse: collapse;
   font-size: 0.875rem;
   line-height: 1.45;
+  table-layout: fixed;       /* consistent column widths within each table */
 }
+
+/* Consistent column widths by column count */
+.cols-2 th:first-child,
+.cols-2 td:first-child { width: 55%; }
+.cols-2 th:last-child,
+.cols-2 td:last-child   { width: 45%; }
+
+.cols-3 th:first-child,
+.cols-3 td:first-child { width: 44%; }
+.cols-3 th:nth-child(2),
+.cols-3 td:nth-child(2) { width: 28%; }
+.cols-3 th:last-child,
+.cols-3 td:last-child   { width: 28%; }
+
+.cols-4 th,
+.cols-4 td { width: 25%; }
+
+.cols-5 th,
+.cols-5 td { width: 20%; }
+
+.cols-6 th,
+.cols-6 td { width: 16.66%; }
 
 .md-table th,
 .md-table td {


### PR DESCRIPTION
Removed leftover 3-yr pooled columns from LA/England rows. Added table-layout:fixed with cols-N CSS for consistent column widths across all tables.