### PR TITLE
fix(govuk): show ISI data in Part A A2/A3 for independent schools

### DIFF
--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-29T19:52:19.879Z",
+    "capturedAt": "2026-04-29T23:43:41.524Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,14 +1123,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 101,
+      "totalTransactions": 171,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,320,000",
+      "medianAllTypes": "£1,150,000",
       "byType": {
-        "Flat / Maisonette": "£1,095,000",
+        "Flat / Maisonette": "£1,060,000",
         "Semi-detached": "£6,050,000",
-        "Detached": "£4,850,000",
-        "Terraced": "£1,300,000"
+        "Detached": "£4,227,000",
+        "Terraced": "£2,625,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-29T19:52:09.517Z",
+    "capturedAt": "2026-04-29T23:43:30.840Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 55,
+      "totalTransactions": 149,
       "postcodesQueried": 100,
-      "medianAllTypes": "£432,000",
+      "medianAllTypes": "£421,000",
       "byType": {
         "Terraced": "£435,000",
-        "Semi-detached": "£475,000",
-        "Flat / Maisonette": "£269,950"
+        "Flat / Maisonette": "£240,000",
+        "Semi-detached": "£470,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-29T19:51:34.827Z",
+    "capturedAt": "2026-04-29T23:42:54.986Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 251,
+      "totalTransactions": 350,
       "postcodesQueried": 100,
-      "medianAllTypes": "£435,000",
+      "medianAllTypes": "£428,500",
       "byType": {
-        "Semi-detached": "£485,000",
+        "Semi-detached": "£496,500",
         "Terraced": "£405,000",
-        "Flat / Maisonette": "£267,000",
-        "Detached": "£550,000"
+        "Flat / Maisonette": "£240,000",
+        "Detached": "£560,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-29T19:51:42.306Z",
+    "capturedAt": "2026-04-29T23:43:02.831Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,13 +918,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 213,
+      "totalTransactions": 405,
       "postcodesQueried": 100,
-      "medianAllTypes": "£425,000",
+      "medianAllTypes": "£450,000",
       "byType": {
-        "Semi-detached": "£450,000",
-        "Terraced": "£423,000",
-        "Detached": "£555,000",
+        "Semi-detached": "£515,000",
+        "Terraced": "£430,000",
+        "Detached": "£610,000",
         "Flat / Maisonette": "£260,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-29T19:52:13.006Z",
+    "capturedAt": "2026-04-29T23:43:34.383Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,14 +170,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 179,
+      "totalTransactions": 175,
       "postcodesQueried": 100,
-      "medianAllTypes": "£355,000",
+      "medianAllTypes": "£390,000",
       "byType": {
-        "Flat / Maisonette": "£290,000",
-        "Terraced": "£570,000",
-        "Detached": "£1,040,000",
-        "Semi-detached": "£840,000"
+        "Flat / Maisonette": "£301,500",
+        "Terraced": "£585,000",
+        "Detached": "£1,150,000",
+        "Semi-detached": "£770,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-29T19:52:16.516Z",
+    "capturedAt": "2026-04-29T23:43:37.958Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,13 +1110,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 144,
+      "totalTransactions": 90,
       "postcodesQueried": 74,
-      "medianAllTypes": "£688,500",
+      "medianAllTypes": "£715,000",
       "byType": {
-        "Flat / Maisonette": "£312,500",
-        "Detached": "£985,000",
-        "Semi-detached": "£699,950",
+        "Flat / Maisonette": "£300,000",
+        "Detached": "£1,075,000",
+        "Semi-detached": "£715,000",
         "Terraced": "£625,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-29T19:51:50.949Z",
+    "capturedAt": "2026-04-29T23:43:10.704Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,12 +981,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 230,
+      "totalTransactions": 242,
       "postcodesQueried": 100,
-      "medianAllTypes": "£526,500",
+      "medianAllTypes": "£520,000",
       "byType": {
-        "Flat / Maisonette": "£480,000",
-        "Terraced": "£650,000",
+        "Flat / Maisonette": "£456,500",
+        "Terraced": "£690,000",
         "Semi-detached": "£665,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-29T19:52:05.602Z",
+    "capturedAt": "2026-04-29T23:43:26.606Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-29T19:51:56.241Z",
+    "capturedAt": "2026-04-29T23:43:16.153Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,14 +1927,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 220,
+      "totalTransactions": 265,
       "postcodesQueried": 100,
-      "medianAllTypes": "£455,000",
+      "medianAllTypes": "£450,000",
       "byType": {
-        "Semi-detached": "£476,000",
-        "Terraced": "£440,000",
-        "Flat / Maisonette": "£280,000",
-        "Detached": "£810,000"
+        "Semi-detached": "£475,000",
+        "Terraced": "£430,000",
+        "Flat / Maisonette": "£272,000",
+        "Detached": "£805,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/govuk-fixtures.test.js
+++ b/functions/research/__tests__/govuk-fixtures.test.js
@@ -83,16 +83,16 @@ const EXPECTATIONS = {
     shouldNotContain: ['Key Stage 1', 'Key Stage 2'],
   },
   'independent-primary': {
-    shouldContain:    ['Independent'],
+    shouldContain:    ['ISI'],
     // Independent schools: Ofsted narrative won't be present
     shouldNotContain: ['Key Stage 4', 'Key Stage 5'],
   },
   'independent-secondary': {
-    shouldContain:    ['Independent'],
+    shouldContain:    ['ISI'],
     shouldNotContain: ['Key Stage 1', 'Key Stage 2'],
   },
   'independent-all-through': {
-    shouldContain:    ['Independent'],
+    shouldContain:    ['ISI'],
     shouldNotContain: [],
   },
 };

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-29T19:52:19.880Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-29T23:43:41.526Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -263,7 +263,10 @@ Recommendation
 pupils in Years 7   and 8.
 
 ### A4 — What the School Needs to Improve (verbatim from Ofsted PDF — reproduce exactly in A4 section)
-_Independent school — not applicable._
+Recommendation
+3.3In the context of the excellent outcomes, the school might wish 
+to consider further ways of  promoting excellent  behaviour,  social cohesion and well-being for 
+pupils in Years 7   and 8.
 
 ### School Pupil Ethnicity (DfE Census)
 - Pupil ethnicity (DfE 2024/25): White 0% · Mixed 0% · Asian 0% · Black 0%
@@ -273,7 +276,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 101 sales, 5yr): median £1,320,000 · by type: Flat / Maisonette £1,095,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £1,300,000
+- House prices (~800m, 171 sales, 5yr): median £1,150,000 · by type: Flat / Maisonette £1,060,000, Semi-detached £6,050,000, Detached £4,227,000, Terraced £2,625,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-29T19:52:09.518Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-29T23:43:30.841Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -788,7 +788,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 55 sales, 5yr): median £432,000 · by type: Terraced £435,000, Semi-detached £475,000, Flat / Maisonette £269,950
+- House prices (~800m, 149 sales, 5yr): median £421,000 · by type: Terraced £435,000, Flat / Maisonette £240,000, Semi-detached £470,000
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-29T19:51:34.828Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-29T23:42:54.987Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -67,7 +67,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 251 sales, 5yr): median £435,000 · by type: Semi-detached £485,000, Terraced £405,000, Flat / Maisonette £267,000, Detached £550,000
+- House prices (~800m, 350 sales, 5yr): median £428,500 · by type: Semi-detached £496,500, Terraced £405,000, Flat / Maisonette £240,000, Detached £560,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-29T19:51:42.308Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-29T23:43:02.832Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -273,7 +273,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 213 sales, 5yr): median £425,000 · by type: Semi-detached £450,000, Terraced £423,000, Detached £555,000, Flat / Maisonette £260,000
+- House prices (~800m, 405 sales, 5yr): median £450,000 · by type: Semi-detached £515,000, Terraced £430,000, Detached £610,000, Flat / Maisonette £260,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-29T19:52:13.007Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-29T23:43:34.385Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -58,7 +58,10 @@ Recommendation
 for themselves how to explore and deepen their own learning equally strongly across all subjects.
 
 ### A4 — What the School Needs to Improve (verbatim from Ofsted PDF — reproduce exactly in A4 section)
-_Independent school — not applicable._
+Recommendation
+3.3The school is    advised to make the following improvement.
+Further strengthen pupils’ creativity and depth of understanding by enabling them to determine 
+for themselves how to explore and deepen their own learning equally strongly across all subjects.
 
 ### School Pupil Ethnicity (DfE Census)
 - Pupil ethnicity (DfE 2024/25): White 0% · Mixed 0% · Asian 0% · Black 0%
@@ -68,7 +71,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 179 sales, 5yr): median £355,000 · by type: Flat / Maisonette £290,000, Terraced £570,000, Detached £1,040,000, Semi-detached £840,000
+- House prices (~800m, 175 sales, 5yr): median £390,000 · by type: Flat / Maisonette £301,500, Terraced £585,000, Detached £1,150,000, Semi-detached £770,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-29T19:52:16.517Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-29T23:43:37.960Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -273,7 +273,155 @@ beyond their expectations at both GCSE and A   level. In both groups, this refle
 of support and challenge, provided by  teaching  and
 
 ### A4 — What the School Needs to Improve (verbatim from Ofsted PDF — reproduce exactly in A4 section)
-_Independent school — not applicable._
+Recommendations
+3.3In the context of the excellent outcomes, the school might wish to consider:
+Ensuring that all teaching and learning reflects fully the aims of the school and strives to match 
+the best practice seen, so that pupils are always challenged to be their best.
+The quality of pupils’ academic and other achievements
+3.4The quality of pupils’ academic and other achievements is    excellent.
+3.5The school meets its  aim of challenging  pupils to be the  best  they  can, inside and outside the 
+classroom. However, there is scope for further progress in the delivery of some lessons and in ensuring 
+that all assessment provides effective information for pupils. The school meets its aim through largely 
+dynamic and very focused teaching which enables pupils to reach their full potential but again, in a 
+small minority of lessons seen, this was not the case.  At both GCSE and A    level, pupils achieve well 
+above the national average for maintained schools  and above the  average for maintained selective 
+schools. At both stages, they make excellent progress in relation to the average for pupils of similar 
+abilities. There is no statistically significant difference in  the achievements of pupils with  special 
+educational needs  and/or disabilities (SEND)  relative to other pupils. The most able pupils  achieve 
+beyond their expectations at both GCSE and A   level. In both groups, this reflects the strong programme 
+of support and challenge, provided by  teaching  and  a  consequence  of the  school’s leadership.  Girls 
+have outperformed boys at  GCSE  in terms of value-added data,  but the reverse has been true at A 
+
+Educational Quality Inspection11
+© Independent Schools Inspectorate 2019Caterham School –   May 2019
+level. Boarders have performed more strongly than other pupils at both GCSE and A level, reflecting 
+their positive experience of boarding at the school, which they were keen to describe to inspectors. 
+Pupils achieve this success  because the school has  put in place  a  very  effective  system to  monitor 
+pupils’ progress, which helps pupils to decide targets. A large majority of leavers from Year 13 last year 
+gained places at their first choice of university, many of which have high standards of entry.
+3.6Pupils demonstrate an excellent level of knowledge, skills and understanding  in  all areas  of their 
+learning. They have a strong grasp of concepts and are confident in discussing these in lessons and 
+developing their ideas in written form. This was seen in a   GCSE geography lesson where there was a 
+high level of questioning and response on tectonic processes, guided by some expert teaching. Pupils 
+benefit considerably from their  excellent  relationships with  staff. This promotes confidence  in the 
+pupils and in turn  leads them  on to experiment with new ideas without fear  of  being wrong. They 
+thrive in a climate where the philosophy is    that mistakes are an opportunity to learn. In a psychology 
+lesson in Year  12,  pupils  were comfortable  in engaging in  discussion and experimenting with their 
+ideas. Pupils approach new work confidently, as seen in a   modern foreign languages class in Year 7 
+where they quickly learnt the methods for telling the time. A    high level of knowledge was seen across 
+the subjects, such as in a GCSE history lesson on the Cold War where pupils confidently made excellent 
+links with prior work and then applied these effectively in the challenging written task. Pupils were 
+effective in demonstrating their understanding in an A-level physics lesson where they delivered short, 
+snappy presentations on subjects of their own choice. Strong progress in learning was evident in the 
+work scrutiny of  all years  and in individual  lessons, such as an English  class  in Year  7    where pupils 
+rapidly acquired an understanding of terminology relating to the five senses. However, this progress 
+and achievement is not the case in all lessons with a   few being rather slow in pace and not challenging 
+enough. Similarly,  whilst in most subjects, pupils  benefit from valuable, formative marking  and 
+assessment, in a    small minority of  subjects, the marking is  inconsistent and limited so that pupils 
+cannot identify  weaknesses  and make progress.  Pupils’  use of technology in  their learning is 
+widespread and effective, reflecting the school’s investment in new learning. Pupils display a   high level 
+of commitment and  achievement  in their sport. The quality of their creative and aesthetic work is 
+outstanding, as heard in the very high level of musicianship in rehearsals and seen in the variety of 
+accomplished artwork  on display throughout the school. The creativity of the pupils is    supported by 
+the excellent facilities and resources provided by the leadership and management of the school.
+
+Educational Quality Inspection12
+© Independent Schools Inspectorate 2019Caterham School –   May 2019
+3.7Pupils have excellent levels of literacy and communicate powerfully both orally and in their written 
+work. They are confident and articulate in formal and informal situations and across all subjects. They 
+always communicate respectfully to their peers. In many lessons, the pupils work effectively in small 
+groups sharing ideas. Pupils were fully engaged in a   sports lesson and communicated effectively with 
+each other, giving and receiving instructions and support. In some lessons, pupils demonstrate their 
+communication skills by questioning and challenging ideas, but in others, they are more passive but 
+still listen and take useful notes. Pupils display excellent linguistic skills across the subjects, seen in a 
+Latin group in Year 12 where pupils were using highly sophisticated terminology in analysing a poetry 
+text. Those pupils with English as an additional language (EAL) show strong linguistic skills, as seen in 
+an economics lesson in Year 12, where they confidently used complex technical language in discussion. 
+Pupils develop their oral communication skills through the wide range of activities offered in the co-
+curricular programme, such as the  ‘Thunk’ club, as well as  in  more informal  situations, such as an 
+activity for boarders where they can discuss openly any concerns they have. This latter opportunity is 
+much appreciated by the boarders and reflects the excellent approach of the boarding staff.
+3.8Pupils display  very effective numeracy skills  and successfully apply this  excellent mathematical 
+understanding to other subjects, as seen in the work scrutiny of all years. Pupils are confident in using 
+their mathematics, in subjects  such as business studies, economics, geography and science.  These 
+strong skills were seen in A    level PE projects, where pupils used their knowledge to analyse data and 
+produce informative graphs. A    chemistry group in Year 12 confidently referred to logarithmic scale to 
+describe the changes  in pH of an acid as a    base was added. Senior  pupils  said that they  benefit 
+enormously from the opportunities to support younger pupils with their mathematical work, as the 
+act of  explaining concepts enhances  their own  understanding. This is just  one element  of  the 
+encouragement given by the school’s leadership to  providing  support for  learning: others include 
+mathematics clinics for all years and specific lessons for A-level scientists not taking mathematics as a 
+subject. Pupils value this support and feel it   has improved their understanding.
+
+Educational Quality Inspection13
+© Independent Schools Inspectorate 2019Caterham School –   May 2019
+3.9Pupils make very good use of the excellent structure of ICT available to them in the school and develop 
+a high level of competence across the subjects as a   result. A    majority of pupils, now take computer 
+science as a   GCSE  subject, enhancing their skills.  Pupils said that they  find working  with the  tablets 
+provided by the school a   useful source of support for their learning and this was seen in a   Latin lesson 
+in Year 7, where pupils were using their tablets confidently to complete the task. Pupils also expressed 
+an appreciation for the learning platforms  available in  school because they enable them  to  keep in 
+contact with their teachers  easily  and help their progress. Pupils with SEND and those  with  EAL 
+especially make constant use of ICT in their work, aiding their understanding significantly. Pupils use 
+ICT in different ways with noted success. An English group in Year 9, for example, used multi-media 
+techniques to enhance  their  study of The Tempest. Pupils  also make effective use of co-curricular 
+activities such as a   junior coding club and the excellent opportunities in the innovation centre, where 
+they were making a   range of projects including programmable robots. Pupils participate in a number 
+of national projects  to develop  and display their technological skills. This level  of  involvement and 
+achievement is the  consequence of  the considerable  investment of time and resources by the 
+leadership of  the school, supported by the  trustees. Their  efforts have  received recognition in the 
+receipt of a   national award for excellent use of technology.
+3.10Pupils demonstrate study skills of a very high order and are very confident in their work. They display 
+strong evidence of independent learning, seen in the range of research projects undertaken by pupils 
+of all  ages.  Some pupils  commented  how  much they have benefited from the advice  they  have 
+received in time management with  their  work.  Boarders also expressed real appreciation for  the 
+excellent work habits they have  been encouraged  to  adopt at the school. Pupils apply their prior 
+knowledge and understanding to new situations effectively and reach perceptive conclusions. In an A-
+level psychology lesson, pupils recalled previous work on ‘schemas’ in discussion and then moved on 
+successfully to develop their own hypotheses on how these could both help and hinder individuals in 
+their lives. In  a   GCSE modern foreign languages lesson,  pupils confidently used  skills of synthesis in 
+categorising words and concepts  on daily routines around the house. In two classics groups, pupils 
+demonstrated exceptional ability in analysing texts and reaching conclusions of the highest order.
+3.11Pupils achieve considerable  success in a    wide range of activities and benefit significantly from the 
+remarkably strong co-curricular programme. There are many clubs  on offer in  the  school,  many  of 
+which are led by pupils and the participation in these is    high, which in turn broadens pupils’ personal 
+development. This level of pupils’ involvement is monitored by regular audits of the programme. The 
+excellent quality of the activities is    seen across the school. The chamber choir in rehearsal were singing 
+two demanding choral pieces unaccompanied and displayed not just a   very high technical skill but also 
+a strong emotional response to the music. Video footage demonstrates the high  quality of  drama 
+productions. There is a   considerable range of sporting activities, involving both individual and team 
+participation and the high level of pupils’ achievement is evident. There are 17 competitive sports on 
+offer and a    large majority of pupils  have  represented the  school in  this way. There are notable 
+successes at both individual and team level,  including national competitors in swimming, sailing, 
+lacrosse and rugby as well as team success, such as in lacrosse, where the first team reached the semi-
+finals of a   national competition. Large numbers of pupils take part in the Combined Cadet Force (CCF) 
+and benefit from the opportunity  to learn a  wide range  of new skills  that  this offers. The Duke of 
+Edinburgh's Award (DoE) scheme is    also popular, and pupils gain awards at all three levels: 100 pupils 
+are currently engaged in the silver and gold awards.  Individuals have gained awards in a   variety of co-
+curricular areas, such as best delegate at the Model United Nations assembly, best  speaker in  the 
+English Speaking Union  finals and  24 gold medal winners in the national senior maths challenge 
+competition. This excellent provision stems from the leadership’s strong belief in educating the whole 
+person, and pupils express their appreciation of these opportunities, the boarders particularly valuing 
+the activities. 
+3.12For the most part, pupils demonstrate a   very positive attitude to their work, encouraged by the largely 
+committed and purposeful teaching, though in a   very small minority of lessons, this was less apparent. 
+They are strong independent learners,  but they also engage effectively in  collaborative tasks with 
+
+Educational Quality Inspection14
+© Independent Schools Inspectorate 2019Caterham School –   May 2019
+great success, both in the classroom and in their extra-curricular activities. The atmosphere in lessons 
+is excellent with pupils showing a   serious level of focus on the task in hand, and this was seen across 
+the subjects and years. Pupils undertake independent research projects, not just in the sixth form but 
+also lower down the school, and this reflects their own initiative and the encouragement offered by 
+the school in promoting this aspect  of learning. The  school has created  a  common, focused 
+atmosphere that enables pupils to feel safe and comfortable with their learning, so that even when 
+they do not immediately  understand and need clarification, they know they will be helped without 
+judgement. Opportunities such as the  digital innovation project enable  pupils to develop their  own 
+ideas and show initiative in their  learning. An example  was a  project of the  Da Vinci  society with a 
+team of pupils designing and building an excellent arcade machine from the 1980s. Pupils of all ages 
+express significant appreciation for the study buddy scheme where senior pupils work with younger 
+ones, saying how much it   has helped their confidence, not just in their work but also in their personal 
+development.
 
 ### School Pupil Ethnicity (DfE Census)
 - Pupil ethnicity (DfE 2024/25): White 0% · Mixed 0% · Asian 0% · Black 0%
@@ -283,7 +431,7 @@ _Independent school — not applicable._
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 144 sales, 5yr): median £688,500 · by type: Flat / Maisonette £312,500, Detached £985,000, Semi-detached £699,950, Terraced £625,000
+- House prices (~800m, 90 sales, 5yr): median £715,000 · by type: Flat / Maisonette £300,000, Detached £1,075,000, Semi-detached £715,000, Terraced £625,000
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-29T19:51:50.950Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-29T23:43:10.706Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -292,7 +292,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 230 sales, 5yr): median £526,500 · by type: Flat / Maisonette £480,000, Terraced £650,000, Semi-detached £665,000
+- House prices (~800m, 242 sales, 5yr): median £520,000 · by type: Flat / Maisonette £456,500, Terraced £690,000, Semi-detached £665,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-29T19:52:05.603Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-29T23:43:26.608Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-29T19:51:56.242Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-29T23:43:16.154Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -414,7 +414,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 220 sales, 5yr): median £455,000 · by type: Semi-detached £476,000, Terraced £440,000, Flat / Maisonette £280,000, Detached £810,000
+- House prices (~800m, 265 sales, 5yr): median £450,000 · by type: Semi-detached £475,000, Terraced £430,000, Flat / Maisonette £272,000, Detached £805,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -3235,7 +3235,7 @@ ${fmtFinancial(financial)}
 ${fmtOfstedSlim(ofsted, identity?.isIndependent ?? false)}
 
 ### A4 — What the School Needs to Improve (verbatim from Ofsted PDF — reproduce exactly in A4 section)
-${identity?.isIndependent ? '_Independent school — not applicable._' : ofsted?.nextSteps ? ofsted.nextSteps : ofsted?.overall ? `_No improvement requirements stated. Ofsted grade: ${ofsted.overall}._` : '_Not retrieved — link to full Ofsted PDF if available._'}
+${identity?.isIndependent ? (ofsted?.recommendations || ofsted?.nextSteps || '_Independent school — no improvement recommendations available._') : ofsted?.nextSteps ? ofsted.nextSteps : ofsted?.overall ? `_No improvement requirements stated. Ofsted grade: ${ofsted.overall}._` : '_Not retrieved — link to full Ofsted PDF if available._'}
 
 ### School Pupil Ethnicity (DfE Census)
 ${fmtSchoolEthnicitySlim(schoolEthnicity)}
@@ -3714,8 +3714,22 @@ export function renderPartA(school, flags = {}) {
   // ────────────────────────────────────────────────────────────────────────────
   {
     let body;
-    if (isIndependent) {
-      body = 'Independent school — Ofsted does not inspect independent schools. See ISI inspection reports at isi.net.';
+    if (isIndependent && !ofsted?.overall) {
+      body = 'Independent school — ISI inspection report not retrieved. See isi.net.';
+    } else if (isIndependent && ofsted?.overall) {
+      // ISI data available — render same table format as Ofsted
+      const lines = [];
+      if (ofsted.date)         lines.push(`Inspection date: ${ofsted.date}`);
+      if (ofsted.framework)    lines.push(`\nFramework: ${ofsted.framework}`);
+      if (ofsted.safeguarding) lines.push(`\nSafeguarding: ${ofsted.safeguarding}`);
+      lines.push('');
+      lines.push('| Area | Grade |', '|---|---|');
+      lines.push(`| Overall | ${ofsted.overall} |`);
+      if (ofsted.academicJudgment)
+        lines.push(`| Academic achievement | ${ofsted.academicJudgment} |`);
+      if (ofsted.personalJudgment)
+        lines.push(`| Personal development | ${ofsted.personalJudgment} |`);
+      body = lines.join('\n');
     } else if (!ofsted?.overall) {
       body = `_Not retrieved — check [reports.ofsted.gov.uk](https://reports.ofsted.gov.uk) by URN or school name._`;
     } else {
@@ -3793,8 +3807,12 @@ export function renderPartA(school, flags = {}) {
   // ────────────────────────────────────────────────────────────────────────────
   {
     let body;
-    if (isIndependent) {
-      body = '_Independent school — not applicable._';
+    if (isIndependent && ofsted?.recommendations) {
+      body = ofsted.recommendations;  // ISI recommendations
+    } else if (isIndependent && ofsted?.nextSteps) {
+      body = ofsted.nextSteps;  // ISI next steps (alt key)
+    } else if (isIndependent) {
+      body = '_Independent school — no improvement recommendations available._';
     } else if (ofsted?.nextSteps) {
       body = ofsted.nextSteps;
     } else if (ofsted?.overall) {


### PR DESCRIPTION
Part A A2 now renders ISI grades table. A3 shows ISI recommendations. Slim block A4 shows ISI recommendations when available.