### PR TITLE
fix(govuk): show KS4 data when Attainment 8 present but no Progress 8

### DIFF
--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-29T23:43:41.524Z",
+    "capturedAt": "2026-04-29T23:52:35.860Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,13 +1123,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 171,
+      "totalTransactions": 254,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,150,000",
+      "medianAllTypes": "£1,215,000",
       "byType": {
-        "Flat / Maisonette": "£1,060,000",
+        "Flat / Maisonette": "£1,025,000",
         "Semi-detached": "£6,050,000",
-        "Detached": "£4,227,000",
+        "Detached": "£4,300,000",
         "Terraced": "£2,625,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-29T23:43:30.840Z",
+    "capturedAt": "2026-04-29T23:52:23.876Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 149,
+      "totalTransactions": 108,
       "postcodesQueried": 100,
-      "medianAllTypes": "£421,000",
+      "medianAllTypes": "£410,250",
       "byType": {
-        "Terraced": "£435,000",
-        "Flat / Maisonette": "£240,000",
-        "Semi-detached": "£470,000"
+        "Terraced": "£440,000",
+        "Flat / Maisonette": "£255,000",
+        "Semi-detached": "£465,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-29T23:42:54.986Z",
+    "capturedAt": "2026-04-29T23:51:49.581Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,13 +298,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 350,
+      "totalTransactions": 406,
       "postcodesQueried": 100,
       "medianAllTypes": "£428,500",
       "byType": {
-        "Semi-detached": "£496,500",
-        "Terraced": "£405,000",
-        "Flat / Maisonette": "£240,000",
+        "Semi-detached": "£490,000",
+        "Terraced": "£422,500",
+        "Flat / Maisonette": "£235,000",
         "Detached": "£560,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-29T23:43:02.831Z",
+    "capturedAt": "2026-04-29T23:51:57.913Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,12 +918,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 405,
+      "totalTransactions": 466,
       "postcodesQueried": 100,
-      "medianAllTypes": "£450,000",
+      "medianAllTypes": "£442,500",
       "byType": {
         "Semi-detached": "£515,000",
-        "Terraced": "£430,000",
+        "Terraced": "£423,000",
         "Detached": "£610,000",
         "Flat / Maisonette": "£260,000"
       },

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-29T23:43:34.383Z",
+    "capturedAt": "2026-04-29T23:52:27.731Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,14 +170,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 175,
+      "totalTransactions": 169,
       "postcodesQueried": 100,
-      "medianAllTypes": "£390,000",
+      "medianAllTypes": "£335,000",
       "byType": {
-        "Flat / Maisonette": "£301,500",
-        "Terraced": "£585,000",
+        "Flat / Maisonette": "£290,000",
+        "Terraced": "£570,000",
         "Detached": "£1,150,000",
-        "Semi-detached": "£770,000"
+        "Semi-detached": "£625,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-29T23:43:37.958Z",
+    "capturedAt": "2026-04-29T23:52:31.588Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,13 +1110,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 90,
+      "totalTransactions": 171,
       "postcodesQueried": 74,
-      "medianAllTypes": "£715,000",
+      "medianAllTypes": "£665,000",
       "byType": {
-        "Flat / Maisonette": "£300,000",
-        "Detached": "£1,075,000",
-        "Semi-detached": "£715,000",
+        "Flat / Maisonette": "£312,500",
+        "Detached": "£989,668",
+        "Semi-detached": "£699,950",
         "Terraced": "£625,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-29T23:43:10.704Z",
+    "capturedAt": "2026-04-29T23:52:07.134Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,13 +981,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 242,
+      "totalTransactions": 325,
       "postcodesQueried": 100,
       "medianAllTypes": "£520,000",
       "byType": {
         "Flat / Maisonette": "£456,500",
         "Terraced": "£690,000",
-        "Semi-detached": "£665,000"
+        "Semi-detached": "£675,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-29T23:43:26.606Z",
+    "capturedAt": "2026-04-29T23:52:19.880Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-29T23:43:16.153Z",
+    "capturedAt": "2026-04-29T23:52:11.611Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,14 +1927,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 265,
+      "totalTransactions": 126,
       "postcodesQueried": 100,
-      "medianAllTypes": "£450,000",
+      "medianAllTypes": "£437,500",
       "byType": {
-        "Semi-detached": "£475,000",
-        "Terraced": "£430,000",
+        "Semi-detached": "£465,000",
+        "Terraced": "£425,000",
         "Flat / Maisonette": "£272,000",
-        "Detached": "£805,000"
+        "Detached": "£850,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-29T23:43:41.526Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-29T23:52:35.862Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -10,6 +10,18 @@
 **Links:** https://www.get-information-schools.service.gov.uk/Establishments/Establishment/Details/100065 · https://www.compare-school-performance.service.gov.uk/school/100065 · https://financial-benchmarking-and-insights-tool.education.gov.uk/school/100065 · https://reports.ofsted.gov.uk/provider/21/100065
 
 ### Academic Results (DfE)
+
+**Key Stage 4 (2024/25)**
+| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Cohort size | 183 | 127 | 56 | — | — | — | — |
+| Attainment 8 | 15.9 | 22.9 | 0 | — | — | — | 46.4 |
+| Grade 5+ English & Maths | 0.0% | 0.0% | 0.0% | — | — | — | 45.9% |
+| Grade 4+ English & Maths | 0.0% | 0.0% | 0.0% | — | — | — | 68.8% |
+| EBacc 5+ | 0.0% | 0.0% | 0.0% | — | — | — | — |
+| EBacc 4+ | 0.0% | 0.0% | 0.0% | — | — | — | 28.6% |
+| Entering EBacc | 0.0% | — | — | — | — | — | 24.7% |
+| EBacc APS | 0.68 | 0.98 | 0 | — | — | — | — |
 
 **Key Stage 5 / 16–18 (2024/25)**
 | Metric | School | National avg |
@@ -276,7 +288,7 @@ pupils in Years 7   and 8.
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 171 sales, 5yr): median £1,150,000 · by type: Flat / Maisonette £1,060,000, Semi-detached £6,050,000, Detached £4,227,000, Terraced £2,625,000
+- House prices (~800m, 254 sales, 5yr): median £1,215,000 · by type: Flat / Maisonette £1,025,000, Semi-detached £6,050,000, Detached £4,300,000, Terraced £2,625,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-29T23:43:30.841Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-29T23:52:23.879Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -788,7 +788,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 149 sales, 5yr): median £421,000 · by type: Terraced £435,000, Flat / Maisonette £240,000, Semi-detached £470,000
+- House prices (~800m, 108 sales, 5yr): median £410,250 · by type: Terraced £440,000, Flat / Maisonette £255,000, Semi-detached £465,000
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-29T23:42:54.987Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-29T23:51:49.583Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -67,7 +67,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 350 sales, 5yr): median £428,500 · by type: Semi-detached £496,500, Terraced £405,000, Flat / Maisonette £240,000, Detached £560,000
+- House prices (~800m, 406 sales, 5yr): median £428,500 · by type: Semi-detached £490,000, Terraced £422,500, Flat / Maisonette £235,000, Detached £560,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-29T23:43:02.832Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-29T23:51:57.916Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -273,7 +273,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 405 sales, 5yr): median £450,000 · by type: Semi-detached £515,000, Terraced £430,000, Detached £610,000, Flat / Maisonette £260,000
+- House prices (~800m, 466 sales, 5yr): median £442,500 · by type: Semi-detached £515,000, Terraced £423,000, Detached £610,000, Flat / Maisonette £260,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-29T23:43:34.385Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-29T23:52:27.732Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -71,7 +71,7 @@ for themselves how to explore and deepen their own learning equally strongly acr
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 175 sales, 5yr): median £390,000 · by type: Flat / Maisonette £301,500, Terraced £585,000, Detached £1,150,000, Semi-detached £770,000
+- House prices (~800m, 169 sales, 5yr): median £335,000 · by type: Flat / Maisonette £290,000, Terraced £570,000, Detached £1,150,000, Semi-detached £625,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-29T23:43:37.960Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-29T23:52:31.592Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -10,6 +10,18 @@
 **Links:** https://www.get-information-schools.service.gov.uk/Establishments/Establishment/Details/125427 · https://www.compare-school-performance.service.gov.uk/school/125427 · https://financial-benchmarking-and-insights-tool.education.gov.uk/school/125427 · https://reports.ofsted.gov.uk/provider/21/125427
 
 ### Academic Results (DfE)
+
+**Key Stage 4 (2024/25)**
+| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Cohort size | 152 | 84 | 68 | — | — | — | — |
+| Attainment 8 | 17.6 | 16.6 | 18.7 | — | — | — | 46.4 |
+| Grade 5+ English & Maths | 0.0% | 0.0% | 0.0% | — | — | — | 45.9% |
+| Grade 4+ English & Maths | 0.0% | 0.0% | 0.0% | — | — | — | 68.8% |
+| EBacc 5+ | 0.0% | 0.0% | 0.0% | — | — | — | — |
+| EBacc 4+ | 0.0% | 0.0% | 0.0% | — | — | — | 28.6% |
+| Entering EBacc | 0.0% | — | — | — | — | — | 24.7% |
+| EBacc APS | 0.97 | 0.96 | 0.98 | — | — | — | — |
 
 **Key Stage 5 / 16–18 (2024/25)**
 | Metric | School | National avg |
@@ -431,7 +443,7 @@ development.
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 90 sales, 5yr): median £715,000 · by type: Flat / Maisonette £300,000, Detached £1,075,000, Semi-detached £715,000, Terraced £625,000
+- House prices (~800m, 171 sales, 5yr): median £665,000 · by type: Flat / Maisonette £312,500, Detached £989,668, Semi-detached £699,950, Terraced £625,000
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-29T23:43:10.706Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-29T23:52:07.139Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -292,7 +292,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 242 sales, 5yr): median £520,000 · by type: Flat / Maisonette £456,500, Terraced £690,000, Semi-detached £665,000
+- House prices (~800m, 325 sales, 5yr): median £520,000 · by type: Flat / Maisonette £456,500, Terraced £690,000, Semi-detached £675,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-29T23:43:26.608Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-29T23:52:19.883Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-29T23:43:16.154Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-29T23:52:11.613Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -414,7 +414,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 265 sales, 5yr): median £450,000 · by type: Semi-detached £475,000, Terraced £430,000, Flat / Maisonette £272,000, Detached £805,000
+- House prices (~800m, 126 sales, 5yr): median £437,500 · by type: Semi-detached £465,000, Terraced £425,000, Flat / Maisonette £272,000, Detached £850,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -2736,7 +2736,10 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
   }
 
   // ── KS4 (secondary) ───────────────────────────────────────────────────────
-  if (/secondary|all.through/i.test(ph) || v('P8MEA')) {
+  // Show if the school has ANY KS4 data (not just Progress 8 — some independent
+  // schools have Attainment 8 but no P8, and all-through schools may show
+  // "Not applicable" as their phase).
+  if (/secondary|all.through/i.test(ph) || v('P8MEA') || v('ATT8SCR') || v('PTL2BASICS_95') || v('PTL2BASICS_94')) {
     // Attainment
     const att8     = v('ATT8SCR');
     const att8g    = v('ATT8SCR_GIRLS');


### PR DESCRIPTION
Independent schools with Not applicable phase now show KS4 when they have Attainment 8 or grade 5+ EM data.