### PR TITLE
fix: 2-col A5 tables, C1 evidence badges scoped to C1 only

### DIFF
--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-30T06:47:37.577Z",
+    "capturedAt": "2026-04-30T07:04:06.254Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,14 +1123,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 188,
+      "totalTransactions": 207,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,250,000",
+      "medianAllTypes": "£1,175,000",
       "byType": {
-        "Flat / Maisonette": "£1,083,000",
+        "Flat / Maisonette": "£1,050,000",
         "Semi-detached": "£6,050,000",
-        "Detached": "£4,850,000",
-        "Terraced": "£2,745,000"
+        "Detached": "£4,300,000",
+        "Terraced": "£2,625,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-30T06:47:26.897Z",
+    "capturedAt": "2026-04-30T07:03:56.065Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 110,
+      "totalTransactions": 111,
       "postcodesQueried": 100,
       "medianAllTypes": "£421,000",
       "byType": {
-        "Terraced": "£430,000",
-        "Flat / Maisonette": "£222,500",
-        "Semi-detached": "£470,000"
+        "Terraced": "£429,000",
+        "Semi-detached": "£475,000",
+        "Flat / Maisonette": "£243,500"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-30T06:46:52.195Z",
+    "capturedAt": "2026-04-30T07:03:22.925Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 212,
+      "totalTransactions": 246,
       "postcodesQueried": 100,
       "medianAllTypes": "£435,000",
       "byType": {
-        "Semi-detached": "£505,000",
-        "Terraced": "£430,000",
-        "Flat / Maisonette": "£230,000",
-        "Detached": "£560,000"
+        "Semi-detached": "£487,500",
+        "Terraced": "£423,000",
+        "Flat / Maisonette": "£222,500",
+        "Detached": "£530,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-30T06:47:00.213Z",
+    "capturedAt": "2026-04-30T07:03:30.621Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,14 +918,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 332,
+      "totalTransactions": 241,
       "postcodesQueried": 100,
-      "medianAllTypes": "£437,500",
+      "medianAllTypes": "£465,000",
       "byType": {
         "Semi-detached": "£505,000",
-        "Terraced": "£423,000",
-        "Detached": "£580,000",
-        "Flat / Maisonette": "£262,500"
+        "Terraced": "£415,000",
+        "Detached": "£565,000",
+        "Flat / Maisonette": "£260,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-30T06:47:30.559Z",
+    "capturedAt": "2026-04-30T07:03:59.550Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,13 +170,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 195,
+      "totalTransactions": 133,
       "postcodesQueried": 100,
-      "medianAllTypes": "£355,000",
+      "medianAllTypes": "£345,000",
       "byType": {
-        "Flat / Maisonette": "£290,000",
-        "Terraced": "£570,000",
-        "Detached": "£1,040,000",
+        "Flat / Maisonette": "£300,000",
+        "Terraced": "£550,000",
+        "Detached": "£1,150,000",
         "Semi-detached": "£714,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-30T06:47:33.999Z",
+    "capturedAt": "2026-04-30T07:04:02.953Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,13 +1110,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 93,
+      "totalTransactions": 158,
       "postcodesQueried": 74,
-      "medianAllTypes": "£699,950",
+      "medianAllTypes": "£675,000",
       "byType": {
-        "Flat / Maisonette": "£305,000",
-        "Detached": "£900,000",
-        "Semi-detached": "£699,950"
+        "Flat / Maisonette": "£312,500",
+        "Detached": "£950,000",
+        "Semi-detached": "£699,950",
+        "Terraced": "£672,500"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-30T06:47:07.986Z",
+    "capturedAt": "2026-04-30T07:03:38.176Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,12 +981,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 181,
+      "totalTransactions": 196,
       "postcodesQueried": 100,
-      "medianAllTypes": "£513,000",
+      "medianAllTypes": "£525,000",
       "byType": {
         "Flat / Maisonette": "£450,000",
-        "Terraced": "£690,000",
+        "Terraced": "£725,000",
         "Semi-detached": "£665,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-30T06:47:22.675Z",
+    "capturedAt": "2026-04-30T07:03:51.713Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",
@@ -2942,18 +2942,7 @@
       "Other ethnic group: Arab": 0.3,
       "Other ethnic group: Any other ethnic group": 1.3
     },
-    "pricePaid": {
-      "radiusM": 800,
-      "yearsBack": 5,
-      "totalTransactions": 9,
-      "postcodesQueried": 100,
-      "medianAllTypes": "£251,000",
-      "byType": {
-        "Detached": "£905,000",
-        "Flat / Maisonette": "£210,000"
-      },
-      "source": "HM Land Registry Price Paid Data"
-    },
+    "pricePaid": null,
     "income": {
       "msoaName": "Reigate and Banstead 012",
       "netAnnualHouseholdIncome": "£41,000",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-30T06:47:12.852Z",
+    "capturedAt": "2026-04-30T07:03:42.418Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,13 +1927,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 216,
+      "totalTransactions": 177,
       "postcodesQueried": 100,
       "medianAllTypes": "£450,000",
       "byType": {
-        "Semi-detached": "£475,000",
-        "Terraced": "£440,000",
+        "Semi-detached": "£480,000",
         "Flat / Maisonette": "£250,000",
+        "Terraced": "£437,500",
         "Detached": "£810,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-30T06:47:37.578Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-30T07:04:06.255Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -14,9 +14,9 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| Attainment 8 score | 15.9 | 22.9 | 22.9 | — | 15.9 | 15.9 | — | 46.4 |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 15.9 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -32,9 +32,9 @@
 | Languages | 48.6% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL |
-|---:|---:|---:|---:|---:|---:|
-| EBacc APS | 0.68 | 0.98 | 0.98 | — | 0.68 | 0.68 |
+| Metric | All pupils |
+|---:|---:|
+| EBacc APS | 0.68 |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -115,7 +115,7 @@ pupils in Years 7   and 8.
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 188 sales, 5yr): median £1,250,000 · by type: Flat / Maisonette £1,083,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £2,745,000
+- House prices (~800m, 207 sales, 5yr): median £1,175,000 · by type: Flat / Maisonette £1,050,000, Semi-detached £6,050,000, Detached £4,300,000, Terraced £2,625,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T06:47:26.898Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T07:03:56.068Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -14,9 +14,9 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| Attainment 8 score | 80.1 | 79 | 79 | 82 | 72.2 | 80.5 | — | 46.4 |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 80.1 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -27,19 +27,19 @@
 | Open element | 23.4 |
 
 **Grade 5+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| % grade 5+ English & maths | 99.0% | — | 99.0% | 99.0% | 99.0% | 99.0% | — | 45.9% |
+| Metric | All pupils |
+|---:|---:|
+| % grade 5+ English & maths | 99.0% |
 
 **Grade 4+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| % grade 4+ English & maths | 99.5% | — | 99.5% | 99.5% | 99.5% | 99.5% | — | 68.8% |
+| Metric | All pupils |
+|---:|---:|
+| % grade 4+ English & maths | 99.5% |
 
 **EBacc entry**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL |
-|---:|---:|---:|---:|---:|---:|
-| % entering EBacc | 93.7% | — | 93.7% | 93.7% | 93.7% | 93.7% |
+| Metric | All pupils |
+|---:|---:|
+| % entering EBacc | 93.7% |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -51,11 +51,11 @@
 | Languages | 97.4% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL |
-|---:|---:|---:|---:|---:|---:|
-| % EBacc 5+ | 91.6% | — | 91.6% | 91.6% | 71.4% | 91.6% |
-| % EBacc 4+ | 93.7% | — | 93.7% | 93.7% | 85.7% | 93.7% |
-| EBacc APS | 7.93 | 7.82 | 7.82 | 8.14 | 7.1 | 7.97 |
+| Metric | All pupils |
+|---:|---:|
+| % EBacc 5+ | 91.6% |
+| % EBacc 4+ | 93.7% |
+| EBacc APS | 7.93 |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -138,7 +138,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 110 sales, 5yr): median £421,000 · by type: Terraced £430,000, Flat / Maisonette £222,500, Semi-detached £470,000
+- House prices (~800m, 111 sales, 5yr): median £421,000 · by type: Terraced £429,000, Semi-detached £475,000, Flat / Maisonette £243,500
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-30T06:46:52.195Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-30T07:03:22.925Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -51,7 +51,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 212 sales, 5yr): median £435,000 · by type: Semi-detached £505,000, Terraced £430,000, Flat / Maisonette £230,000, Detached £560,000
+- House prices (~800m, 246 sales, 5yr): median £435,000 · by type: Semi-detached £487,500, Terraced £423,000, Flat / Maisonette £222,500, Detached £530,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-30T06:47:00.213Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-30T07:03:30.622Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -53,7 +53,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 332 sales, 5yr): median £437,500 · by type: Semi-detached £505,000, Terraced £423,000, Detached £580,000, Flat / Maisonette £262,500
+- House prices (~800m, 241 sales, 5yr): median £465,000 · by type: Semi-detached £505,000, Terraced £415,000, Detached £565,000, Flat / Maisonette £260,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-30T06:47:30.560Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-30T07:03:59.550Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -64,7 +64,7 @@ for themselves how to explore and deepen their own learning equally strongly acr
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 195 sales, 5yr): median £355,000 · by type: Flat / Maisonette £290,000, Terraced £570,000, Detached £1,040,000, Semi-detached £714,000
+- House prices (~800m, 133 sales, 5yr): median £345,000 · by type: Flat / Maisonette £300,000, Terraced £550,000, Detached £1,150,000, Semi-detached £714,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-30T06:47:34.011Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-30T07:04:02.954Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -14,9 +14,9 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| Attainment 8 score | 17.6 | 16.6 | 16.6 | 18.7 | 17.6 | 17.6 | — | 46.4 |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 17.6 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -30,9 +30,9 @@
 | Languages | 75.0% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL |
-|---:|---:|---:|---:|---:|---:|
-| EBacc APS | 0.97 | 0.96 | 0.96 | 0.98 | 0.97 | 0.97 |
+| Metric | All pupils |
+|---:|---:|
+| EBacc APS | 0.97 |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -270,7 +270,7 @@ development.
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 93 sales, 5yr): median £699,950 · by type: Flat / Maisonette £305,000, Detached £900,000, Semi-detached £699,950
+- House prices (~800m, 158 sales, 5yr): median £675,000 · by type: Flat / Maisonette £312,500, Detached £950,000, Semi-detached £699,950, Terraced £672,500
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-30T06:47:07.987Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-30T07:03:38.177Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -72,7 +72,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 181 sales, 5yr): median £513,000 · by type: Flat / Maisonette £450,000, Terraced £690,000, Semi-detached £665,000
+- House prices (~800m, 196 sales, 5yr): median £525,000 · by type: Flat / Maisonette £450,000, Terraced £725,000, Semi-detached £665,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-30T06:47:22.676Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-30T07:03:51.714Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College
@@ -75,7 +75,6 @@ _Not retrieved — link to full Ofsted PDF if available._
 - Geography codes: LSOA E01030620 · MSOA E02006386
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Crime 6/10, Living Environment 4/10
 - Household income (MSOA): mean gross £71,000 (Census 2021 era) · net £41,000 (ONS 2018) · after housing £34,800
-- House prices (~800m, 9 sales, 5yr): median £251,000 · by type: Detached £905,000, Flat / Maisonette £210,000
 - Ethnicity (LSOA, Census 2021): White 88% · Asian 5% · Mixed 4% · Black 2% · Other 2%
 - Qualifications (OA, Census 2021): level 4+ 56% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 50% · routine/manual 12%

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-30T06:47:12.853Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-30T07:03:42.419Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -14,9 +14,9 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| Attainment 8 score | 52.4 | 51.6 | 51.6 | 53.4 | 36.8 | 56.9 | — | 46.4 |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 52.4 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -27,19 +27,19 @@
 | Open element | 15.9 |
 
 **Grade 5+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| % grade 5+ English & maths | 61.0% | — | 61.0% | 61.0% | 61.0% | 61.0% | — | 45.9% |
+| Metric | All pupils |
+|---:|---:|
+| % grade 5+ English & maths | 61.0% |
 
 **Grade 4+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| % grade 4+ English & maths | 76.4% | — | 76.4% | 76.4% | 76.4% | 76.4% | — | 68.8% |
+| Metric | All pupils |
+|---:|---:|
+| % grade 4+ English & maths | 76.4% |
 
 **EBacc entry**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL |
-|---:|---:|---:|---:|---:|---:|
-| % entering EBacc | 78.7% | — | 78.7% | 78.7% | 78.7% | 78.7% |
+| Metric | All pupils |
+|---:|---:|
+| % entering EBacc | 78.7% |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -51,11 +51,11 @@
 | Languages | 78.7% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged | EAL |
-|---:|---:|---:|---:|---:|---:|
-| % EBacc 5+ | 30.7% | — | 30.7% | 30.7% | 10.0% | 30.7% |
-| % EBacc 4+ | 40.9% | — | 40.9% | 40.9% | 14.0% | 40.9% |
-| EBacc APS | 4.79 | 4.75 | 4.75 | 4.83 | 3.22 | 5.36 |
+| Metric | All pupils |
+|---:|---:|
+| % EBacc 5+ | 30.7% |
+| % EBacc 4+ | 40.9% |
+| EBacc APS | 4.79 |
 
 ### Financial Benchmarking (FBIT)
 - In-year balance: -£236,369
@@ -104,7 +104,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 216 sales, 5yr): median £450,000 · by type: Semi-detached £475,000, Terraced £440,000, Flat / Maisonette £250,000, Detached £810,000
+- House prices (~800m, 177 sales, 5yr): median £450,000 · by type: Semi-detached £480,000, Flat / Maisonette £250,000, Terraced £437,500, Detached £810,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -2518,7 +2518,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     },
     {
       heading: 'Progress (KS1 to KS2)',
-      cols: 'abgdelE',
+      cols: 'all',
       rows: [
         { label: 'Reading progress', var: 'READPROG', ciLo: 'READPROG_LO', ciHi: 'READPROG_HI', eng: '0' },
         { label: 'Writing progress', var: 'WRITPROG', ciLo: 'WRITPROG_LO', ciHi: 'WRITPROG_HI', eng: '0' },
@@ -2530,7 +2530,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
   const KS4_TOPICS = [
     {
       heading: 'Attainment 8',
-      cols: 'abgdelE',
+      cols: 'all',
       rows: [
         { label: 'Attainment 8 score', var: 'ATT8SCR', eng: String(nat4.ATT8SCR) },
       ],
@@ -2547,28 +2547,28 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     },
     {
       heading: 'Progress 8',
-      cols: 'abgdelE',
+      cols: 'all',
       rows: [
         { label: 'Progress 8', var: 'P8MEA', ciLo: 'P8LOWER', ciHi: 'P8UPPER', eng: String(nat4.P8MEA) },
       ],
     },
     {
       heading: 'Grade 5+ English & Maths',
-      cols: 'abgdelE',
+      cols: 'all',
       rows: [
         { label: '% grade 5+ English & maths', var: 'PTL2BASICS_95', eng: nat4.PTL2BASICS_95 + '%' },
       ],
     },
     {
       heading: 'Grade 4+ English & Maths',
-      cols: 'abgdelE',
+      cols: 'all',
       rows: [
         { label: '% grade 4+ English & maths', var: 'PTL2BASICS_94', eng: nat4.PTL2BASICS_94 + '%' },
       ],
     },
     {
       heading: 'EBacc entry',
-      cols: 'abgde',
+      cols: 'all',
       rows: [
         { label: '% entering EBacc', var: 'PTEBACC_E_PTQ_EE', eng: nat4.PTEBACC_E_PTQ_EE + '%' },
       ],
@@ -2586,7 +2586,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     },
     {
       heading: 'EBacc achievement',
-      cols: 'abgde',
+      cols: 'all',
       rows: [
         { label: '% EBacc 5+', var: 'PTEBACC_95' },
         { label: '% EBacc 4+', var: 'PTEBACC_94', eng: nat4.PTEBACC_94 + '%' },

--- a/web/app.js
+++ b/web/app.js
@@ -178,15 +178,17 @@
 
   function renderTable(container, tableLines) {
     var table = document.createElement("table");
-    var headerCells = null;
     var tbody = null;
     var colCount = 0;
+    var isEvidenceTable = false; // only C1 has "Evidence level" column
 
     tableLines.forEach(function (line, i) {
       if (isTableSeparator(line)) return;
       var cells = parseTableRow(line);
       if (i === 0) {
         colCount = cells.length;
+        // Detect C1 table by "Evidence level" header
+        isEvidenceTable = cells.some(function (c) { return /evidence\s*level/i.test(c); });
         var thead = document.createElement("thead");
         var tr = document.createElement("tr");
         cells.forEach(function (cell) {
@@ -202,22 +204,24 @@
         var tr = document.createElement("tr");
         cells.forEach(function (cell, ci) {
           var td = document.createElement("td");
-          // Detect evidence-level keywords and wrap in coloured badge
-          var trimmed = cell.trim();
-          var evidenceClass = null;
-          if (/^Strong$/i.test(trimmed)) evidenceClass = 'evidence-strong';
-          else if (/^Present$/i.test(trimmed)) evidenceClass = 'evidence-good';
-          else if (/^Mixed$/i.test(trimmed)) evidenceClass = 'evidence-mixed';
-          else if (/^Weak$/i.test(trimmed)) evidenceClass = 'evidence-weak';
-          else if (/^Not evident$/i.test(trimmed)) evidenceClass = 'evidence-unknown';
-          if (evidenceClass) {
-            var span = document.createElement("span");
-            span.className = evidenceClass;
-            span.textContent = trimmed;
-            td.appendChild(span);
-          } else {
-            appendTextWithLinks(td, cell);
+          if (isEvidenceTable) {
+            var trimmed = cell.trim();
+            var evidenceClass = null;
+            if (/^Strong$/i.test(trimmed)) evidenceClass = 'evidence-strong';
+            else if (/^Present$/i.test(trimmed)) evidenceClass = 'evidence-good';
+            else if (/^Mixed$/i.test(trimmed)) evidenceClass = 'evidence-mixed';
+            else if (/^Weak$/i.test(trimmed)) evidenceClass = 'evidence-weak';
+            else if (/^Not evident$/i.test(trimmed)) evidenceClass = 'evidence-unknown';
+            if (evidenceClass) {
+              var span = document.createElement("span");
+              span.className = evidenceClass;
+              span.textContent = trimmed;
+              td.appendChild(span);
+              tr.appendChild(td);
+              return;
+            }
           }
+          appendTextWithLinks(td, cell);
           tr.appendChild(td);
         });
         tbody.appendChild(tr);


### PR DESCRIPTION
A5 tables now clean 2-column format. C1 evidence badges only fire on Evidence level columns.