### PR TITLE
feat: variant finder, multi-column KS4, prior-year comparators

### DIFF
--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-30T07:04:06.254Z",
+    "capturedAt": "2026-04-30T07:43:43.665Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,13 +1123,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 207,
+      "totalTransactions": 153,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,175,000",
+      "medianAllTypes": "£1,150,000",
       "byType": {
-        "Flat / Maisonette": "£1,050,000",
+        "Flat / Maisonette": "£1,000,000",
         "Semi-detached": "£6,050,000",
-        "Detached": "£4,300,000",
+        "Detached": "£4,227,000",
         "Terraced": "£2,625,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-30T07:03:56.065Z",
+    "capturedAt": "2026-04-30T07:43:32.695Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 111,
+      "totalTransactions": 169,
       "postcodesQueried": 100,
-      "medianAllTypes": "£421,000",
+      "medianAllTypes": "£425,000",
       "byType": {
-        "Terraced": "£429,000",
-        "Semi-detached": "£475,000",
-        "Flat / Maisonette": "£243,500"
+        "Terraced": "£436,000",
+        "Flat / Maisonette": "£240,000",
+        "Semi-detached": "£470,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-30T07:03:22.925Z",
+    "capturedAt": "2026-04-30T07:42:58.072Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 246,
+      "totalTransactions": 215,
       "postcodesQueried": 100,
       "medianAllTypes": "£435,000",
       "byType": {
-        "Semi-detached": "£487,500",
         "Terraced": "£423,000",
-        "Flat / Maisonette": "£222,500",
-        "Detached": "£530,000"
+        "Semi-detached": "£485,000",
+        "Flat / Maisonette": "£275,000",
+        "Detached": "£595,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-30T07:03:30.621Z",
+    "capturedAt": "2026-04-30T07:43:05.972Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,13 +918,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 241,
+      "totalTransactions": 463,
       "postcodesQueried": 100,
-      "medianAllTypes": "£465,000",
+      "medianAllTypes": "£440,000",
       "byType": {
-        "Semi-detached": "£505,000",
-        "Terraced": "£415,000",
-        "Detached": "£565,000",
+        "Semi-detached": "£515,000",
+        "Terraced": "£423,000",
+        "Detached": "£610,000",
         "Flat / Maisonette": "£260,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-30T07:03:59.550Z",
+    "capturedAt": "2026-04-30T07:43:36.614Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,14 +170,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 133,
+      "totalTransactions": 157,
       "postcodesQueried": 100,
       "medianAllTypes": "£345,000",
       "byType": {
-        "Flat / Maisonette": "£300,000",
-        "Terraced": "£550,000",
-        "Detached": "£1,150,000",
-        "Semi-detached": "£714,000"
+        "Flat / Maisonette": "£290,000",
+        "Terraced": "£570,000",
+        "Detached": "£1,040,000",
+        "Semi-detached": "£770,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-30T07:04:02.953Z",
+    "capturedAt": "2026-04-30T07:43:40.176Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,12 +1110,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 158,
+      "totalTransactions": 118,
       "postcodesQueried": 74,
-      "medianAllTypes": "£675,000",
+      "medianAllTypes": "£700,000",
       "byType": {
-        "Flat / Maisonette": "£312,500",
-        "Detached": "£950,000",
+        "Flat / Maisonette": "£305,000",
+        "Detached": "£990,000",
         "Semi-detached": "£699,950",
         "Terraced": "£672,500"
       },

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-30T07:03:38.176Z",
+    "capturedAt": "2026-04-30T07:43:13.628Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,13 +981,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 196,
+      "totalTransactions": 223,
       "postcodesQueried": 100,
-      "medianAllTypes": "£525,000",
+      "medianAllTypes": "£520,000",
       "byType": {
-        "Flat / Maisonette": "£450,000",
-        "Terraced": "£725,000",
-        "Semi-detached": "£665,000"
+        "Flat / Maisonette": "£440,000",
+        "Terraced": "£650,000",
+        "Semi-detached": "£675,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-30T07:03:51.713Z",
+    "capturedAt": "2026-04-30T07:43:27.976Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",
@@ -2942,7 +2942,18 @@
       "Other ethnic group: Arab": 0.3,
       "Other ethnic group: Any other ethnic group": 1.3
     },
-    "pricePaid": null,
+    "pricePaid": {
+      "radiusM": 800,
+      "yearsBack": 5,
+      "totalTransactions": 9,
+      "postcodesQueried": 100,
+      "medianAllTypes": "£251,000",
+      "byType": {
+        "Detached": "£905,000",
+        "Flat / Maisonette": "£210,000"
+      },
+      "source": "HM Land Registry Price Paid Data"
+    },
     "income": {
       "msoaName": "Reigate and Banstead 012",
       "netAnnualHouseholdIncome": "£41,000",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-30T07:03:42.418Z",
+    "capturedAt": "2026-04-30T07:43:17.791Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,14 +1927,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 177,
+      "totalTransactions": 234,
       "postcodesQueried": 100,
-      "medianAllTypes": "£450,000",
+      "medianAllTypes": "£444,000",
       "byType": {
-        "Semi-detached": "£480,000",
-        "Flat / Maisonette": "£250,000",
-        "Terraced": "£437,500",
-        "Detached": "£810,000"
+        "Semi-detached": "£475,000",
+        "Terraced": "£445,000",
+        "Flat / Maisonette": "£257,500",
+        "Detached": "£805,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-30T07:04:06.255Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-30T07:43:43.667Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -14,9 +14,10 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils |
-|---:|---:|
-| Attainment 8 score | 15.9 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| Attainment 8 score | 15.9 | 22.9 | — | — |
+| Attainment 8 score (prior year) | 20.3 | — | — | — |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -32,9 +33,10 @@
 | Languages | 48.6% |
 
 **EBacc achievement**
-| Metric | All pupils |
-|---:|---:|
-| EBacc APS | 0.68 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| EBacc APS | 0.68 | 0.98 | — | — |
+| EBacc APS (prior year) | 1.37 | — | — | — |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -115,7 +117,7 @@ pupils in Years 7   and 8.
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 207 sales, 5yr): median £1,175,000 · by type: Flat / Maisonette £1,050,000, Semi-detached £6,050,000, Detached £4,300,000, Terraced £2,625,000
+- House prices (~800m, 153 sales, 5yr): median £1,150,000 · by type: Flat / Maisonette £1,000,000, Semi-detached £6,050,000, Detached £4,227,000, Terraced £2,625,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T07:03:56.068Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T07:43:32.698Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -14,9 +14,10 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils |
-|---:|---:|
-| Attainment 8 score | 80.1 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| Attainment 8 score | 80.1 | 79 | 82 | 72.2 |
+| Attainment 8 score (prior year) | 81 | — | — | — |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -27,19 +28,22 @@
 | Open element | 23.4 |
 
 **Grade 5+ English & Maths**
-| Metric | All pupils |
-|---:|---:|
-| % grade 5+ English & maths | 99.0% |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % grade 5+ English & maths | 99.0% | 98.4% | 100.0% | — |
+| % grade 5+ English & maths (prior year) | 99.0% | — | — | — |
 
 **Grade 4+ English & Maths**
-| Metric | All pupils |
-|---:|---:|
-| % grade 4+ English & maths | 99.5% |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % grade 4+ English & maths | 99.5% | 99.2% | 100.0% | — |
+| % grade 4+ English & maths (prior year) | 99.5% | — | — | — |
 
 **EBacc entry**
-| Metric | All pupils |
-|---:|---:|
-| % entering EBacc | 93.7% |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % entering EBacc | 93.7% | 92.8% | 95.5% | — |
+| % entering EBacc (prior year) | 95.8% | — | — | — |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -51,11 +55,14 @@
 | Languages | 97.4% |
 
 **EBacc achievement**
-| Metric | All pupils |
-|---:|---:|
-| % EBacc 5+ | 91.6% |
-| % EBacc 4+ | 93.7% |
-| EBacc APS | 7.93 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % EBacc 5+ | 91.6% | 90.4% | 93.9% | 71.4% |
+| % EBacc 5+ (prior year) | 92.7% | — | — | — |
+| % EBacc 4+ | 93.7% | 92.8% | 95.5% | 85.7% |
+| % EBacc 4+ (prior year) | 94.2% | — | — | — |
+| EBacc APS | 7.93 | 7.82 | 8.14 | 7.1 |
+| EBacc APS (prior year) | 8 | — | — | — |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -138,7 +145,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 111 sales, 5yr): median £421,000 · by type: Terraced £429,000, Semi-detached £475,000, Flat / Maisonette £243,500
+- House prices (~800m, 169 sales, 5yr): median £425,000 · by type: Terraced £436,000, Flat / Maisonette £240,000, Semi-detached £470,000
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-30T07:03:22.925Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-30T07:42:58.073Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -51,7 +51,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 246 sales, 5yr): median £435,000 · by type: Semi-detached £487,500, Terraced £423,000, Flat / Maisonette £222,500, Detached £530,000
+- House prices (~800m, 215 sales, 5yr): median £435,000 · by type: Terraced £423,000, Semi-detached £485,000, Flat / Maisonette £275,000, Detached £595,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-30T07:03:30.622Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-30T07:43:05.974Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -15,8 +15,8 @@
 **Attainment**
 | Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
 |---:|---:|---:|---:|---:|---:|---:|---:|
-| % meeting expected standard (RWM) | 74% | — | 74% | 74% | 63% | 90% | — | 61% |
-| % achieving higher standard (RWM) | 15% | — | 15% | 15% | 9% | 23% | — | 9% |
+| % meeting expected standard (RWM) | 74% | — | — | 63% | 90% | — | 61% |
+| % achieving higher standard (RWM) | 15% | — | — | 9% | 23% | — | 9% |
 
 **Attainment — subject breakdown**
 | Metric | All pupils |
@@ -53,7 +53,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 241 sales, 5yr): median £465,000 · by type: Semi-detached £505,000, Terraced £415,000, Detached £565,000, Flat / Maisonette £260,000
+- House prices (~800m, 463 sales, 5yr): median £440,000 · by type: Semi-detached £515,000, Terraced £423,000, Detached £610,000, Flat / Maisonette £260,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-30T07:03:59.550Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-30T07:43:36.615Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -64,7 +64,7 @@ for themselves how to explore and deepen their own learning equally strongly acr
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 133 sales, 5yr): median £345,000 · by type: Flat / Maisonette £300,000, Terraced £550,000, Detached £1,150,000, Semi-detached £714,000
+- House prices (~800m, 157 sales, 5yr): median £345,000 · by type: Flat / Maisonette £290,000, Terraced £570,000, Detached £1,040,000, Semi-detached £770,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-30T07:04:02.954Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-30T07:43:40.179Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -14,9 +14,10 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils |
-|---:|---:|
-| Attainment 8 score | 17.6 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| Attainment 8 score | 17.6 | 16.6 | 18.7 | — |
+| Attainment 8 score (prior year) | 16.8 | — | — | — |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -30,9 +31,10 @@
 | Languages | 75.0% |
 
 **EBacc achievement**
-| Metric | All pupils |
-|---:|---:|
-| EBacc APS | 0.97 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| EBacc APS | 0.97 | 0.96 | 0.98 | — |
+| EBacc APS (prior year) | 0.81 | — | — | — |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -270,7 +272,7 @@ development.
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 158 sales, 5yr): median £675,000 · by type: Flat / Maisonette £312,500, Detached £950,000, Semi-detached £699,950, Terraced £672,500
+- House prices (~800m, 118 sales, 5yr): median £700,000 · by type: Flat / Maisonette £305,000, Detached £990,000, Semi-detached £699,950, Terraced £672,500
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-30T07:03:38.177Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-30T07:43:13.630Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -15,8 +15,8 @@
 **Attainment**
 | Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
 |---:|---:|---:|---:|---:|---:|---:|---:|
-| % meeting expected standard (RWM) | 89% | — | 89% | 89% | 75% | 89% | — | 61% |
-| % achieving higher standard (RWM) | 28% | — | 28% | 28% | 10% | 38% | — | 9% |
+| % meeting expected standard (RWM) | 89% | — | — | 75% | 89% | — | 61% |
+| % achieving higher standard (RWM) | 28% | — | — | 10% | 38% | — | 9% |
 
 **Attainment — subject breakdown**
 | Metric | All pupils |
@@ -72,7 +72,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 196 sales, 5yr): median £525,000 · by type: Flat / Maisonette £450,000, Terraced £725,000, Semi-detached £665,000
+- House prices (~800m, 223 sales, 5yr): median £520,000 · by type: Flat / Maisonette £440,000, Terraced £650,000, Semi-detached £675,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-30T07:03:51.714Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-30T07:43:27.978Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College
@@ -75,6 +75,7 @@ _Not retrieved — link to full Ofsted PDF if available._
 - Geography codes: LSOA E01030620 · MSOA E02006386
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Crime 6/10, Living Environment 4/10
 - Household income (MSOA): mean gross £71,000 (Census 2021 era) · net £41,000 (ONS 2018) · after housing £34,800
+- House prices (~800m, 9 sales, 5yr): median £251,000 · by type: Detached £905,000, Flat / Maisonette £210,000
 - Ethnicity (LSOA, Census 2021): White 88% · Asian 5% · Mixed 4% · Black 2% · Other 2%
 - Qualifications (OA, Census 2021): level 4+ 56% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 50% · routine/manual 12%

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-30T07:03:42.419Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-30T07:43:17.792Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -14,9 +14,10 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils |
-|---:|---:|
-| Attainment 8 score | 52.4 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| Attainment 8 score | 52.4 | 51.6 | 53.4 | 36.8 |
+| Attainment 8 score (prior year) | 52.9 | — | — | — |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -27,19 +28,22 @@
 | Open element | 15.9 |
 
 **Grade 5+ English & Maths**
-| Metric | All pupils |
-|---:|---:|
-| % grade 5+ English & maths | 61.0% |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % grade 5+ English & maths | 61.0% | 59.4% | 63.1% | — |
+| % grade 5+ English & maths (prior year) | 60.7% | — | — | — |
 
 **Grade 4+ English & Maths**
-| Metric | All pupils |
-|---:|---:|
-| % grade 4+ English & maths | 76.4% |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % grade 4+ English & maths | 76.4% | 76.2% | 76.6% | — |
+| % grade 4+ English & maths (prior year) | 76.1% | — | — | — |
 
 **EBacc entry**
-| Metric | All pupils |
-|---:|---:|
-| % entering EBacc | 78.7% |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % entering EBacc | 78.7% | 77.6% | 80.2% | — |
+| % entering EBacc (prior year) | 80.2% | — | — | — |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -51,11 +55,14 @@
 | Languages | 78.7% |
 
 **EBacc achievement**
-| Metric | All pupils |
-|---:|---:|
-| % EBacc 5+ | 30.7% |
-| % EBacc 4+ | 40.9% |
-| EBacc APS | 4.79 |
+| Metric | All pupils | Boys | Girls | Disadvantaged |
+|---:|---:|---:|---:|---:|
+| % EBacc 5+ | 30.7% | 28.0% | 34.2% | 10.0% |
+| % EBacc 5+ (prior year) | 36.4% | — | — | — |
+| % EBacc 4+ | 40.9% | 35.7% | 47.7% | 14.0% |
+| % EBacc 4+ (prior year) | 49.4% | — | — | — |
+| EBacc APS | 4.79 | 4.75 | 4.83 | 3.22 |
+| EBacc APS (prior year) | 4.89 | — | — | — |
 
 ### Financial Benchmarking (FBIT)
 - In-year balance: -£236,369
@@ -104,7 +111,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 177 sales, 5yr): median £450,000 · by type: Semi-detached £480,000, Flat / Maisonette £250,000, Terraced £437,500, Detached £810,000
+- House prices (~800m, 234 sales, 5yr): median £444,000 · by type: Semi-detached £475,000, Terraced £445,000, Flat / Maisonette £257,500, Detached £805,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -2457,6 +2457,22 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
 
   const v = (code) => allRows.find(r => r.variable === code)?.value ?? null;
 
+  // Variant finder — discovers gendered/FSM/EAL/prior-year breakdowns
+  const findVar = (base) => {
+    const r = { all: v(base) };
+    for (const [s, k] of [['_BOYS','boys'],['_GIRLS','girls'],['_FSM6CLA1A','dis'],['_NFSM6CLA1A','ndis'],['_EAL','eal'],['_PREV','prev'],['_PREV2','prev2']]) {
+      const val = v(base + s); if (val != null) r[k] = val;
+    }
+    if (base.startsWith('PT')) {
+      const t = base.slice(2);
+      if (!r.boys) { const bv = v('PB' + t); if (bv != null) r.boys = bv; }
+      if (!r.girls) { const gv = v('PG' + t); if (gv != null) r.girls = gv; }
+    }
+    if (!r.eal && /BASICS/.test(base)) { const ev = v(base.replace('BASICS', 'BASICSEAL')); if (ev != null) r.eal = ev; }
+    if (!r.eal && /EBACC/.test(base)) { const ev = v(base.replace('EBACC', 'EBACCEAL')); if (ev != null) r.eal = ev; }
+    return r;
+  };
+
   // DfE uses 0, 0%, 0.0% as suppression markers for small cohorts.
   const suppressed = (val) => {
     if (val == null) return true;
@@ -2530,7 +2546,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
   const KS4_TOPICS = [
     {
       heading: 'Attainment 8',
-      cols: 'all',
+      cols: 'abgd',
       rows: [
         { label: 'Attainment 8 score', var: 'ATT8SCR', eng: String(nat4.ATT8SCR) },
       ],
@@ -2554,21 +2570,21 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     },
     {
       heading: 'Grade 5+ English & Maths',
-      cols: 'all',
+      cols: 'abgd',
       rows: [
         { label: '% grade 5+ English & maths', var: 'PTL2BASICS_95', eng: nat4.PTL2BASICS_95 + '%' },
       ],
     },
     {
       heading: 'Grade 4+ English & Maths',
-      cols: 'all',
+      cols: 'abgd',
       rows: [
         { label: '% grade 4+ English & maths', var: 'PTL2BASICS_94', eng: nat4.PTL2BASICS_94 + '%' },
       ],
     },
     {
       heading: 'EBacc entry',
-      cols: 'all',
+      cols: 'abgd',
       rows: [
         { label: '% entering EBacc', var: 'PTEBACC_E_PTQ_EE', eng: nat4.PTEBACC_E_PTQ_EE + '%' },
       ],
@@ -2586,7 +2602,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     },
     {
       heading: 'EBacc achievement',
-      cols: 'all',
+      cols: 'abgd',
       rows: [
         { label: '% EBacc 5+', var: 'PTEBACC_95' },
         { label: '% EBacc 4+', var: 'PTEBACC_94', eng: nat4.PTEBACC_94 + '%' },
@@ -2676,49 +2692,39 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
 
       const cells = [row.label];
 
+      const vars = findVar(row.var);
+      const push = (v) => cells.push(v != null ? c(v) : '—');
+
       if (showAll) {
-        let cell = c(val);
+        let cell = c(vars.all);
         if (row.ciLo && row.ciHi) {
           const lo = v(row.ciLo), hi = v(row.ciHi);
-          if (lo != null && hi != null) cell += ` (CI: ${lo} to ${hi})`;
+          if (lo != null && hi != null) cell += ' (CI: ' + lo + ' to ' + hi + ')';
         }
         cells.push(cell);
       }
-      if (showB) {
-        const bvar = row.var + '_BOYS';
-        if (!bvar || bvar === row.var + '_BOYS') cells.push(c(v(row.var.replace('_95','_95').replace('_94','_94') + '_BOYS') || v(row.var + '_BOYS')));
-      }
-      // Simpler: just show All pupils for the main metric, other columns as "—"
-      // This avoids complex suffix-mangling. For a data-driven approach, we
-      // detect gendered/FSM variants by naming convention.
-      if (showB) {
-        // Try common gender suffixes
-        const bVal = v(row.var + '_BOYS') ?? v(row.var.replace(/ALL$/, 'B')) ?? v(row.var.replace('SCR', 'SCR_BOYS'));
-        cells.push(c(bVal));
-      }
-      if (showG) {
-        const gVal = v(row.var + '_GIRLS') ?? v(row.var.replace(/ALL$/, 'G')) ?? v(row.var.replace('SCR', 'SCR_GIRLS'));
-        cells.push(c(gVal));
-      }
-      if (showD) {
-        const dVal = v(row.var + '_FSM6CLA1A') ?? v(row.var.replace('ALL', 'FSM6CLA1A'));
-        cells.push(c(dVal));
-      }
-      if (showEal) {
-        const eVal = v(row.var + '_EAL') ?? v(row.var.replace('ALL', 'EAL'));
-        cells.push(c(eVal));
-      }
-      if (showLa) {
-        // Map to laPerf key
-        cells.push('—');
-      }
-      if (showEng) {
-        cells.push(row.eng ?? '—');
-      }
+      if (showB)   push(vars.boys);
+      if (showG)   push(vars.girls);
+      if (showD)   push(vars.dis);
+      if (showEal) push(vars.eal);
+      if (showLa)  cells.push('—');
+      if (showEng) cells.push(row.eng ?? '—');
 
-      // Only add row if it has any non-dash value beyond the label
       if (cells.slice(1).some(cell => cell !== '—')) {
         lines.push('| ' + cells.join(' | ') + ' |');
+      }
+
+      // Prior-year comparator
+      if (vars.prev != null && !suppressed(vars.prev)) {
+        const pyCells = [row.label + ' (prior year)'];
+        if (showAll) pyCells.push(c(vars.prev));
+        if (showB)   pyCells.push('—');
+        if (showG)   pyCells.push('—');
+        if (showD)   pyCells.push('—');
+        if (showEal) pyCells.push('—');
+        if (showLa)  pyCells.push('—');
+        if (showEng) pyCells.push('—');
+        lines.push('| ' + pyCells.join(' | ') + ' |');
       }
     }
   }


### PR DESCRIPTION
findVar discovers gender/FSM/EAL/prior-year variants. KS4 tables now show Boys/Girls/Disadvantaged columns plus prior-year comparator.