### PR TITLE
fix(govuk): suppress DfE 0% values in Part A tables

### DIFF
--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -3479,7 +3479,13 @@ export function renderPartA(school, flags = {}) {
     .flatMap(([, rows]) => rows);
   const v  = (code) => allRows.find(r => r.variable === code)?.value ?? null;
   const lv = (code) => performance?.L?.find(r => r.variable === code)?.value ?? null;
-  const d  = (val)  => (val != null ? String(val) : '—');
+  // DfE uses 0%, 0.0%, 0.00% as suppression markers.
+  const d  = (val) => {
+    if (val == null) return '—';
+    const s = String(val).trim();
+    if (s === '0%' || s === '0.0%' || s === '0.00%') return '—';
+    return s;
+  };
 
   const sections = [];
 


### PR DESCRIPTION
renderPartA now treats 0%, 0.0%, 0.00% as suppressed data. Fixes independent school ethnicity/FSM showing as zeros.