### PR TITLE
revert: restore pre-refactor A5 multi-table format + DfE mapping doc

### DIFF
--- a/docs/dfe-data-mapping.md
+++ b/docs/dfe-data-mapping.md
@@ -1,0 +1,187 @@
+# DfE Performance Data — Variable Mapping & Render Rules
+
+## School types and available namespaces
+
+| Phase | DfE namespaces | Example |
+|---|---|---|
+| **Infant** (KS1 only) | L, CENSUS_25, ABS_24 | Earlswood Infant |
+| **Junior** (KS2) | L, CENSUS_25, ABS_24, KS2_25 | Earlswood Junior |
+| **Primary** (KS1+KS2) | L, CENSUS_25, ABS_24, KS2_25 | Redriff Primary |
+| **Secondary** (KS4) | L, CENSUS_25, ABS_24, KS4_25, KS4_PUPDEST_25 | Reigate School |
+| **Sixth Form** (KS5) | L, KS5_25, KS5_STUDEST_25 | Reigate College |
+| **Secondary+Sixth** | L, CENSUS_25, ABS_24, KS4_25, KS4_PUPDEST_25, KS5_25, KS5_STUDEST_25 | Latymer School |
+| **Ind. Primary** | L, CENSUS_25 (percentages suppressed) | Micklefield School |
+| **Ind. Secondary** | L, CENSUS_25, KS4_25, KS5_25 (percentages suppressed) | Caterham School |
+| **Ind. All-through** | L, CENSUS_25, KS4_25, KS5_25 (percentages suppressed) | UCS |
+
+## Section mapping
+
+### A1 — School Identity
+*Source: L + GIAS detail*
+
+| Variable | Render Rule |
+|---|---|
+| `officialName` (GIAS) | Always show |
+| `urn` (GIAS) | Always show |
+| `type` (GIAS) | Always show |
+| `phase` (GIAS) | Always show |
+| `AGELOW` / `AGEHIGH` (L) | Show as "ages X–Y" |
+| `la` (GIAS) | Always show |
+| `GENDER` (L) | Show as "Mixed / Boys only / Girls only" |
+| `RELCHAR` (L) | Show unless "Does not apply" |
+| `ADMPOL` (L) | Show unless "Not applicable" |
+| `headteacher` (GIAS detail) | Show if available |
+| `address` (GIAS tile) | Show if available |
+| `capacity` (GIAS detail) | Show if available |
+| `NOR` (CENSUS_25) | Show if available |
+
+### A2 — Ofsted / ISI Inspection Grades
+*Source: Ofsted HTML scrape (state) or ISI PDF parse (independent)*
+
+| State schools | Independent schools |
+|---|---|
+| Overall grade + sub-grades (Quality of Education, Behaviour, Personal Development, Leadership) | ISI overall + academic/personal judgments |
+| Inspection date | Inspection date |
+| Framework marker | ISI framework marker |
+| Safeguarding status | Safeguarding status |
+
+**Render rules:**
+- If independent + ISI data → show ISI grades table
+- If independent + no ISI data → "ISI report not retrieved"
+- If state + Ofsted → show full grades table
+- If state + no Ofsted → "Not retrieved"
+- Flag: green for Outstanding/Exceptional/Excellent, red for RI/Inadequate/Unsatisfactory/Sound
+
+### A3 — Improvement Requirements
+*Source: Ofsted PDF nextSteps or ISI PDF recommendations*
+
+**Render rules:**
+- If nextSteps/recommendations present → show content, flag red
+- If Outstanding/Excellent with none → "No improvement requirements.", flag green
+- Independent + no data → "No recommendations available"
+- State + no data → "Not retrieved"
+
+### A4 — Pupil Census
+*Source: CENSUS_25 + bundled DfE ethnicity index*
+
+| Variable | Render Rule |
+|---|---|
+| `NOR` (NOR) | Always show |
+| `PNUMFSMEVER` (FSM %) | Show unless suppressed (0%, 0.0%, 0.00%) |
+| `PNUMEAL` (EAL %) | Show unless suppressed |
+| `PSENELK` (SEN support %) | Show unless suppressed |
+| `PSENELSE` (EHC plans %) | Show unless suppressed |
+| Ethnicity index (bundled) | Show unless ALL values are 0 (DfE suppression) |
+| National averages | Show for comparison where available |
+
+### A5 — Academic Performance
+*Source: KS2_25, KS4_25, KS5_25*
+
+**Detection rule:** Show each KS stage section ONLY if that namespace exists in the data (data-driven, not phase-driven).
+
+#### KS2 (primary)
+
+**Table 1 — Cohort**
+Show if `TELIG` or `BELIG` or `GELIG` is present and not suppressed.
+
+**Table 2 — Attainment**  
+Format: timeseries (2023 | 2024 | 2025) with LA and England comparator rows.
+| Row | Variable (2025) | Variable (2024) | Variable (2023) | LA key |
+|---|---|---|---|---|
+| % expected standard (RWM) | `PTRWM_EXP` | `PTRWM_EXP_24` | `PTRWM_EXP_23` | `rwm.expected` |
+| % higher standard (RWM) | `PTRWM_HIGH` | `PTRWM_HIGH_24` | `PTRWM_HIGH_23` | `rwm.higher` |
+Show if at least one year has non-suppressed data.
+
+**Table 3 — Scaled scores**
+Same timeseries format.
+| Row | Variable (2025) | Variable (2024) | Variable (2023) |
+|---|---|---|---|
+| Reading | `READ_AVERAGE` | `READ_AVERAGE_24` | `READ_AVERAGE_23` |
+| Maths | `MAT_AVERAGE` | `MAT_AVERAGE_24` | `MAT_AVERAGE_23` |
+| GPS | `GPS_AVERAGE` | `GPS_AVERAGE_24` | `GPS_AVERAGE_23` |
+
+**Table 4 — Progress**
+Format: progress (Subject | Score | Banding | CI)
+| Row | Variable | CI Low | CI High |
+|---|---|---|---|
+| Reading | `READPROG` | `READPROG_LO` | `READPROG_HI` |
+| Writing | `WRITPROG` | `WRITPROG_LO` | `WRITPROG_HI` |
+| Maths | `MATPROG` | `MATPROG_LO` | `MATPROG_HI` |
+Banding: derived from PROGRESS_BAND (1=Well below … 5=Well above)
+
+#### KS4 (secondary)
+
+**Detection rule:** Show KS4 section if `P8MEA` OR `ATT8SCR` OR `PTL2BASICS_95` OR `PTL2BASICS_94` is present.
+
+Tables currently rendered (from the restored pre-refactor code):
+- Cohort size (with gender breakdown if available)
+- Attainment 8 (All / Boys / Girls / Disadvantaged / EAL / Local avg / England)
+- Attainment 8 element breakdown (English, Maths, EBacc, Open — GCSE/non-GCSE)
+- Progress 8 (with CI)
+- Grade 5+ / 4+ English & Maths
+- EBacc entry / achievement / subject detail
+- KS4 destinations
+
+#### KS5 (post-16)
+
+**Detection rule:** Show KS5 section if `TALLPUP_1618` or `TALLPUP_ALEV_1618` is present.
+
+Current tables:
+- A-level attainment (students, entries, grades, best 3)
+- A-level progress (VA score, band, disadvantaged breakdown)
+- Retention
+- Destinations (L3 breakdown, disadvantaged gap)
+- Facilitating subjects
+
+### A6 — Absence
+*Source: ABS_24*
+
+| Variable | Render Rule |
+|---|---|
+| `PERCTOT` | Always show |
+| `PPERSABS10` | Always show |
+| National averages | Show for comparison |
+| Flag: green if below 5%/15%, red if above 8.6%/23.3% |
+
+### A7 — Financial Position
+*Source: FBIT (state) or school website scrape (independent)*
+
+| State schools | Independent schools |
+|---|---|
+| Spend per pupil | Day/boarding fee ranges |
+| In-year balance | Source URL |
+| Revenue reserves | |
+| QTS % | |
+| Pupil:teacher ratio | |
+
+**Render rules:**
+- Independent → show fees if available, else "not retrieved"
+- State → show FBIT data if available, else "not retrieved"
+
+### A8 — Area Profile
+*Source: postcodes.io + Nomis + ONS + IMD + Crystal Roof*
+
+| Variable | Source | Render Rule |
+|---|---|---|
+| Postcode, district, region | postcodes.io | Always show |
+| IMD decile + sub-domains | findthatpostcode.uk | Always show |
+| Household income | Crystal Roof + ONS | Show if available |
+| House prices | Land Registry | Show if available |
+| Ethnicity (LSOA) | Nomis Census 2021 | Show if available |
+| Qualifications | Crystal Roof | Show if available (TEMP) |
+| Flag: red if IMD decile ≤3 or income <£35k |
+
+### A9 — Parent View
+*Source: Ofsted Parent View print page (state only)*
+
+Table: Question | % agree, with ⚠️ flags for low scores.
+
+**Render rules:**
+- Show only if Parent View data was retrieved
+- Skip if independent school (no Parent View for independent schools)
+
+## Suppression rules (applied everywhere)
+
+DfE uses `0`, `0%`, `0.0%`, `0.00%` as suppression markers for small cohorts. These values MUST be rendered as `—` (not as genuine zero). Exception: raw counts like NOR (pupil headcount) where `0` would mean genuinely zero pupils — but this is a theoretical case.
+
+**Implementation:** Every `c()` / `d()` formatting helper must check suppressed values and convert to `—`. Rows with ALL columns suppressed should be HIDDEN.

--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-30T08:24:48.034Z",
+    "capturedAt": "2026-04-30T09:55:32.264Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,14 +1123,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 180,
+      "totalTransactions": 137,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,150,000",
+      "medianAllTypes": "£1,100,000",
       "byType": {
-        "Flat / Maisonette": "£995,000",
+        "Flat / Maisonette": "£920,000",
         "Semi-detached": "£6,050,000",
-        "Detached": "£4,300,000",
-        "Terraced": "£2,500,000"
+        "Detached": "£4,227,000",
+        "Terraced": "£2,250,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-30T08:24:36.916Z",
+    "capturedAt": "2026-04-30T09:55:21.047Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 169,
+      "totalTransactions": 79,
       "postcodesQueried": 100,
-      "medianAllTypes": "£425,000",
+      "medianAllTypes": "£440,000",
       "byType": {
-        "Terraced": "£436,000",
-        "Flat / Maisonette": "£240,000",
-        "Semi-detached": "£470,000"
+        "Terraced": "£440,000",
+        "Flat / Maisonette": "£260,000",
+        "Semi-detached": "£475,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-30T08:23:58.249Z",
+    "capturedAt": "2026-04-30T09:54:45.364Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 279,
+      "totalTransactions": 208,
       "postcodesQueried": 100,
       "medianAllTypes": "£430,000",
       "byType": {
-        "Semi-detached": "£485,000",
-        "Terraced": "£422,500",
-        "Flat / Maisonette": "£244,000",
-        "Detached": "£551,000"
+        "Semi-detached": "£496,500",
+        "Terraced": "£405,000",
+        "Flat / Maisonette": "£242,000",
+        "Detached": "£525,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-30T08:24:06.488Z",
+    "capturedAt": "2026-04-30T09:54:53.955Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,14 +918,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 366,
+      "totalTransactions": 222,
       "postcodesQueried": 100,
-      "medianAllTypes": "£425,000",
+      "medianAllTypes": "£460,000",
       "byType": {
-        "Semi-detached": "£500,000",
-        "Terraced": "£430,000",
-        "Detached": "£595,000",
-        "Flat / Maisonette": "£260,000"
+        "Terraced": "£480,000",
+        "Semi-detached": "£535,000",
+        "Detached": "£890,000",
+        "Flat / Maisonette": "£266,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-30T08:24:40.705Z",
+    "capturedAt": "2026-04-30T09:55:24.733Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,14 +170,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 172,
+      "totalTransactions": 156,
       "postcodesQueried": 100,
-      "medianAllTypes": "£346,000",
+      "medianAllTypes": "£345,000",
       "byType": {
         "Flat / Maisonette": "£290,000",
-        "Terraced": "£540,000",
+        "Terraced": "£610,000",
         "Detached": "£1,150,000",
-        "Semi-detached": "£770,000"
+        "Semi-detached": "£760,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-30T08:24:44.412Z",
+    "capturedAt": "2026-04-30T09:55:28.470Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,12 +1110,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 107,
+      "totalTransactions": 82,
       "postcodesQueried": 74,
-      "medianAllTypes": "£715,000",
+      "medianAllTypes": "£750,000",
       "byType": {
-        "Flat / Maisonette": "£300,000",
-        "Detached": "£985,000",
+        "Flat / Maisonette": "£340,000",
+        "Detached": "£989,668",
         "Semi-detached": "£699,950"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-30T08:24:14.639Z",
+    "capturedAt": "2026-04-30T09:55:02.252Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,12 +981,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 257,
+      "totalTransactions": 240,
       "postcodesQueried": 100,
       "medianAllTypes": "£520,000",
       "byType": {
-        "Flat / Maisonette": "£450,000",
-        "Terraced": "£685,000",
+        "Flat / Maisonette": "£470,000",
+        "Terraced": "£700,000",
         "Semi-detached": "£675,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-30T08:24:32.001Z",
+    "capturedAt": "2026-04-30T09:55:17.143Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-30T08:24:20.993Z",
+    "capturedAt": "2026-04-30T09:55:07.663Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,14 +1927,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 228,
+      "totalTransactions": 257,
       "postcodesQueried": 100,
-      "medianAllTypes": "£450,000",
+      "medianAllTypes": "£455,000",
       "byType": {
-        "Semi-detached": "£480,000",
-        "Terraced": "£425,000",
-        "Flat / Maisonette": "£255,000",
-        "Detached": "£735,000"
+        "Semi-detached": "£480,500",
+        "Terraced": "£440,000",
+        "Flat / Maisonette": "£250,000",
+        "Detached": "£805,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-30T08:24:48.035Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-30T09:55:32.264Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -14,19 +14,16 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| Attainment 8 score | 15.9 | 22.9 | — | — |
-| Attainment 8 score (prior year) | 20.3 | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 15.9 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
 |---:|---:|
 | Maths element | 0.1 |
 | EBacc element | 8.8 |
-| Open element (total) | 7 |
-| Open — GCSE only | 5.8 |
-| Open — non-GCSE | 1.2 |
+| Open element | 7 |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -35,18 +32,9 @@
 | Languages | 48.6% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| EBacc APS | 0.68 | 0.98 | — | — |
-| EBacc APS (prior year) | 1.37 | — | — | — |
-
-**EBacc subject achievement (% of entered pupils)**
 | Metric | All pupils |
 |---:|---:|
-| Maths 9-4 | 0.5% |
-| Maths 9-5 | 0.5% |
-| Languages 9-4 | 100.0% |
-| Languages 9-5 | 100.0% |
+| EBacc APS | 0.68 |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -55,10 +43,8 @@
 |---:|---:|
 | Total 16–18 students | 183 |
 | A-level students | 183 |
-| A-level entries | 535 |
 | Average A-level grade | A |
 | Average A-level points | 48.87 |
-| Average grade (all academic) | A |
 | Best 3 A-levels — grade | A |
 | Best 3 A-levels — points | 49.34 |
 
@@ -68,7 +54,7 @@
 | Progress score (VA) | 0.2 (CI: 0.1 to 0.29) |
 | Progress band | 2 |
 
-**Facilitating subjects**
+**Facilitating subjects & destinations**
 | Metric | All pupils |
 |---:|---:|
 | % AAB in ≥2 facilitating subjects | 54.6% |
@@ -129,7 +115,7 @@ pupils in Years 7   and 8.
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 180 sales, 5yr): median £1,150,000 · by type: Flat / Maisonette £995,000, Semi-detached £6,050,000, Detached £4,300,000, Terraced £2,500,000
+- House prices (~800m, 137 sales, 5yr): median £1,100,000 · by type: Flat / Maisonette £920,000, Semi-detached £6,050,000, Detached £4,227,000, Terraced £2,250,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T08:24:36.918Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T09:55:21.048Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -14,10 +14,9 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| Attainment 8 score | 80.1 | 79 | 82 | 72.2 |
-| Attainment 8 score (prior year) | 81 | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 80.1 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -25,27 +24,22 @@
 | English element | 15.6 |
 | Maths element | 16.4 |
 | EBacc element | 24.6 |
-| Open element (total) | 23.4 |
-| Open — GCSE only | 23.2 |
-| Open — non-GCSE | 0.2 |
+| Open element | 23.4 |
 
 **Grade 5+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % grade 5+ English & maths | 99.0% | 98.4% | 100.0% | — |
-| % grade 5+ English & maths (prior year) | 99.0% | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| % grade 5+ English & maths | 99.0% |
 
 **Grade 4+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % grade 4+ English & maths | 99.5% | 99.2% | 100.0% | — |
-| % grade 4+ English & maths (prior year) | 99.5% | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| % grade 4+ English & maths | 99.5% |
 
 **EBacc entry**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % entering EBacc | 93.7% | 92.8% | 95.5% | — |
-| % entering EBacc (prior year) | 95.8% | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| % entering EBacc | 93.7% |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -57,36 +51,11 @@
 | Languages | 97.4% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % EBacc 5+ | 91.6% | 90.4% | 93.9% | 71.4% |
-| % EBacc 5+ (prior year) | 92.7% | — | — | — |
-| % EBacc 4+ | 93.7% | 92.8% | 95.5% | 85.7% |
-| % EBacc 4+ (prior year) | 94.2% | — | — | — |
-| EBacc APS | 7.93 | 7.82 | 8.14 | 7.1 |
-| EBacc APS (prior year) | 8 | — | — | — |
-
-**EBacc subject achievement (% of entered pupils)**
 | Metric | All pupils |
 |---:|---:|
-| English 9-4 | 99.0% |
-| English 9-5 | 98.4% |
-| Maths 9-4 | 99.5% |
-| Maths 9-5 | 99.5% |
-| Science 9-4 | 100.0% |
-| Science 9-5 | 98.9% |
-| Humanities 9-4 | 100.0% |
-| Humanities 9-5 | 98.4% |
-| Languages 9-4 | 100.0% |
-| Languages 9-5 | 99.5% |
-
-**KS4 destinations (2022/23 leavers)**
-| Metric | All pupils |
-|---:|---:|
-| % sustained education or employment | 100% |
-| % in education | 100% |
-| % sixth form college | 5% |
-| % further education | 2% |
+| % EBacc 5+ | 91.6% |
+| % EBacc 4+ | 93.7% |
+| EBacc APS | 7.93 |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -95,10 +64,8 @@
 |---:|---:|
 | Total 16–18 students | 214 |
 | A-level students | 212 |
-| A-level entries | 813 |
 | Average A-level grade | A- |
 | Average A-level points | 47.33 |
-| Average grade (all academic) | A- |
 | Best 3 A-levels — grade | A- |
 | Best 3 A-levels — points | 48.11 |
 
@@ -116,38 +83,14 @@
 | Average points (disadvantaged) | 41.95 |
 | Progress score (disadvantaged) | -0.34 (CI: -0.64 to -0.03) |
 
-**Retention**
-| Metric | All pupils |
-|---:|---:|
-| % retained to end of course | 99.1% |
-| % retained to 2nd year | 99.1% |
-| % retained (disadvantaged) | 94.4% |
-
-**Level 3 destinations (A-level cohort)**
-| Metric | All pupils |
-|---:|---:|
-| % sustained education or employment | 88% |
-| % higher education | 71% |
-| % employment | 12% |
-| % apprenticeships | 1% |
-| % further education | 3% |
-| % not sustained | 6% |
-
-**Disadvantaged progression gap**
-| Metric | All pupils |
-|---:|---:|
-| % progressed (disadvantaged) | 93% |
-| % progressed (all) | 96% |
-| % HE (disadvantaged) | 73% |
-| % HE (all) | 92% |
-| % top third HE (disadvantaged) | 40% |
-| % top third HE (all) | 74% |
-
-**Facilitating subjects**
+**Facilitating subjects & destinations**
 | Metric | All pupils |
 |---:|---:|
 | % AAB in ≥2 facilitating subjects | 63.2% |
 | % achieving advanced maths | 83.5% |
+| % retained to end of course | 99.1% |
+| % to higher education | 71% |
+| % to any sustained destination | 96% |
 
 ### Financial Benchmarking (FBIT)
 - In-year balance: £340,889
@@ -195,7 +138,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 169 sales, 5yr): median £425,000 · by type: Terraced £436,000, Flat / Maisonette £240,000, Semi-detached £470,000
+- House prices (~800m, 79 sales, 5yr): median £440,000 · by type: Terraced £440,000, Flat / Maisonette £260,000, Semi-detached £475,000
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-30T08:23:58.250Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-30T09:54:45.366Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -51,7 +51,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 279 sales, 5yr): median £430,000 · by type: Semi-detached £485,000, Terraced £422,500, Flat / Maisonette £244,000, Detached £551,000
+- House prices (~800m, 208 sales, 5yr): median £430,000 · by type: Semi-detached £496,500, Terraced £405,000, Flat / Maisonette £242,000, Detached £525,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-30T08:24:06.489Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-30T09:54:53.956Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -15,8 +15,8 @@
 **Attainment**
 | Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
 |---:|---:|---:|---:|---:|---:|---:|---:|
-| % meeting expected standard (RWM) | 74% | — | — | 63% | 90% | — | 61% |
-| % achieving higher standard (RWM) | 15% | — | — | 9% | 23% | — | 9% |
+| % meeting expected standard (RWM) | 74% | — | 74% | 74% | 63% | 90% | — | 61% |
+| % achieving higher standard (RWM) | 15% | — | 15% | 15% | 9% | 23% | — | 9% |
 
 **Attainment — subject breakdown**
 | Metric | All pupils |
@@ -53,7 +53,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 366 sales, 5yr): median £425,000 · by type: Semi-detached £500,000, Terraced £430,000, Detached £595,000, Flat / Maisonette £260,000
+- House prices (~800m, 222 sales, 5yr): median £460,000 · by type: Terraced £480,000, Semi-detached £535,000, Detached £890,000, Flat / Maisonette £266,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-30T08:24:40.707Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-30T09:55:24.734Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -64,7 +64,7 @@ for themselves how to explore and deepen their own learning equally strongly acr
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 172 sales, 5yr): median £346,000 · by type: Flat / Maisonette £290,000, Terraced £540,000, Detached £1,150,000, Semi-detached £770,000
+- House prices (~800m, 156 sales, 5yr): median £345,000 · by type: Flat / Maisonette £290,000, Terraced £610,000, Detached £1,150,000, Semi-detached £760,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-30T08:24:44.413Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-30T09:55:28.472Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -14,18 +14,15 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| Attainment 8 score | 17.6 | 16.6 | 18.7 | — |
-| Attainment 8 score (prior year) | 16.8 | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 17.6 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
 |---:|---:|
 | EBacc element | 9.4 |
-| Open element (total) | 8.2 |
-| Open — GCSE only | 7.8 |
-| Open — non-GCSE | 0.4 |
+| Open element | 8.2 |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -33,16 +30,9 @@
 | Languages | 75.0% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| EBacc APS | 0.97 | 0.96 | 0.98 | — |
-| EBacc APS (prior year) | 0.81 | — | — | — |
-
-**EBacc subject achievement (% of entered pupils)**
 | Metric | All pupils |
 |---:|---:|
-| Languages 9-4 | 100.0% |
-| Languages 9-5 | 99.1% |
+| EBacc APS | 0.97 |
 
 **Key Stage 5 / 16–18 (2024/25)**
 
@@ -51,10 +41,8 @@
 |---:|---:|
 | Total 16–18 students | 176 |
 | A-level students | 176 |
-| A-level entries | 486 |
 | Average A-level grade | A- |
 | Average A-level points | 48.16 |
-| Average grade (all academic) | A- |
 | Best 3 A-levels — grade | A |
 | Best 3 A-levels — points | 48.46 |
 
@@ -64,7 +52,7 @@
 | Progress score (VA) | 0.26 (CI: 0.17 to 0.36) |
 | Progress band | 2 |
 
-**Facilitating subjects**
+**Facilitating subjects & destinations**
 | Metric | All pupils |
 |---:|---:|
 | % AAB in ≥2 facilitating subjects | 49.0% |
@@ -282,7 +270,7 @@ development.
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 107 sales, 5yr): median £715,000 · by type: Flat / Maisonette £300,000, Detached £985,000, Semi-detached £699,950
+- House prices (~800m, 82 sales, 5yr): median £750,000 · by type: Flat / Maisonette £340,000, Detached £989,668, Semi-detached £699,950
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-30T08:24:14.640Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-30T09:55:02.254Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -15,8 +15,8 @@
 **Attainment**
 | Metric | All pupils | Boys | Girls | Disadvantaged | EAL | Local avg | England |
 |---:|---:|---:|---:|---:|---:|---:|---:|
-| % meeting expected standard (RWM) | 89% | — | — | 75% | 89% | — | 61% |
-| % achieving higher standard (RWM) | 28% | — | — | 10% | 38% | — | 9% |
+| % meeting expected standard (RWM) | 89% | — | 89% | 89% | 75% | 89% | — | 61% |
+| % achieving higher standard (RWM) | 28% | — | 28% | 28% | 10% | 38% | — | 9% |
 
 **Attainment — subject breakdown**
 | Metric | All pupils |
@@ -72,7 +72,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 257 sales, 5yr): median £520,000 · by type: Flat / Maisonette £450,000, Terraced £685,000, Semi-detached £675,000
+- House prices (~800m, 240 sales, 5yr): median £520,000 · by type: Flat / Maisonette £470,000, Terraced £700,000, Semi-detached £675,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-30T08:24:32.002Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-30T09:55:17.144Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College
@@ -18,10 +18,8 @@
 |---:|---:|
 | Total 16–18 students | 1497 |
 | A-level students | 1147 |
-| A-level entries | 2570 |
 | Average A-level grade | B- |
 | Average A-level points | 37.7 |
-| Average grade (all academic) | B- |
 | Best 3 A-levels — grade | B |
 | Best 3 A-levels — points | 39.54 |
 
@@ -39,38 +37,14 @@
 | Average points (disadvantaged) | 33.68 |
 | Progress score (disadvantaged) | — (CI: -0.17 to 0.17) |
 
-**Retention**
-| Metric | All pupils |
-|---:|---:|
-| % retained to end of course | 97.6% |
-| % retained to 2nd year | 97.6% |
-| % retained (disadvantaged) | 94.9% |
-
-**Level 3 destinations (A-level cohort)**
-| Metric | All pupils |
-|---:|---:|
-| % sustained education or employment | 89% |
-| % higher education | 50% |
-| % employment | 34% |
-| % apprenticeships | 4% |
-| % further education | 1% |
-| % not sustained | 8% |
-
-**Disadvantaged progression gap**
-| Metric | All pupils |
-|---:|---:|
-| % progressed (disadvantaged) | 62% |
-| % progressed (all) | 69% |
-| % HE (disadvantaged) | 61% |
-| % HE (all) | 66% |
-| % top third HE (disadvantaged) | 6% |
-| % top third HE (all) | 21% |
-
-**Facilitating subjects**
+**Facilitating subjects & destinations**
 | Metric | All pupils |
 |---:|---:|
 | % AAB in ≥2 facilitating subjects | 21.6% |
 | % achieving advanced maths | 23.2% |
+| % retained to end of course | 97.6% |
+| % to higher education | 48% |
+| % to any sustained destination | 69% |
 
 ### Financial Benchmarking (FBIT)
 - In-year balance: £823,000

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-30T08:24:20.995Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-30T09:55:07.664Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -14,10 +14,9 @@
 **Key Stage 4 (2024/25)**
 
 **Attainment 8**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| Attainment 8 score | 52.4 | 51.6 | 53.4 | 36.8 |
-| Attainment 8 score (prior year) | 52.9 | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| Attainment 8 score | 52.4 |
 
 **Attainment 8 breakdown**
 | Metric | All pupils |
@@ -25,27 +24,22 @@
 | English element | 11 |
 | Maths element | 10.6 |
 | EBacc element | 14.9 |
-| Open element (total) | 15.9 |
-| Open — GCSE only | 13.5 |
-| Open — non-GCSE | 2.4 |
+| Open element | 15.9 |
 
 **Grade 5+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % grade 5+ English & maths | 61.0% | 59.4% | 63.1% | — |
-| % grade 5+ English & maths (prior year) | 60.7% | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| % grade 5+ English & maths | 61.0% |
 
 **Grade 4+ English & Maths**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % grade 4+ English & maths | 76.4% | 76.2% | 76.6% | — |
-| % grade 4+ English & maths (prior year) | 76.1% | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| % grade 4+ English & maths | 76.4% |
 
 **EBacc entry**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % entering EBacc | 78.7% | 77.6% | 80.2% | — |
-| % entering EBacc (prior year) | 80.2% | — | — | — |
+| Metric | All pupils |
+|---:|---:|
+| % entering EBacc | 78.7% |
 
 **EBacc entry by subject**
 | Metric | All pupils |
@@ -57,39 +51,11 @@
 | Languages | 78.7% |
 
 **EBacc achievement**
-| Metric | All pupils | Boys | Girls | Disadvantaged |
-|---:|---:|---:|---:|---:|
-| % EBacc 5+ | 30.7% | 28.0% | 34.2% | 10.0% |
-| % EBacc 5+ (prior year) | 36.4% | — | — | — |
-| % EBacc 4+ | 40.9% | 35.7% | 47.7% | 14.0% |
-| % EBacc 4+ (prior year) | 49.4% | — | — | — |
-| EBacc APS | 4.79 | 4.75 | 4.83 | 3.22 |
-| EBacc APS (prior year) | 4.89 | — | — | — |
-
-**EBacc subject achievement (% of entered pupils)**
 | Metric | All pupils |
 |---:|---:|
-| English 9-4 | 81.5% |
-| English 9-5 | 71.3% |
-| Maths 9-4 | 80.7% |
-| Maths 9-5 | 68.1% |
-| Science 9-4 | 74.4% |
-| Science 9-5 | 61.2% |
-| Humanities 9-4 | 68.0% |
-| Humanities 9-5 | 57.7% |
-| Languages 9-4 | 54.0% |
-| Languages 9-5 | 41.5% |
-
-**KS4 destinations (2022/23 leavers)**
-| Metric | All pupils |
-|---:|---:|
-| % sustained education or employment | 93% |
-| % in education | 89% |
-| % sixth form college | 69% |
-| % further education | 16% |
-| % apprenticeships | 2% |
-| % employment | 2% |
-| % not sustained | 6% |
+| % EBacc 5+ | 30.7% |
+| % EBacc 4+ | 40.9% |
+| EBacc APS | 4.79 |
 
 ### Financial Benchmarking (FBIT)
 - In-year balance: -£236,369
@@ -138,7 +104,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 228 sales, 5yr): median £450,000 · by type: Semi-detached £480,000, Terraced £425,000, Flat / Maisonette £255,000, Detached £735,000
+- House prices (~800m, 257 sales, 5yr): median £455,000 · by type: Semi-detached £480,500, Terraced £440,000, Flat / Maisonette £250,000, Detached £805,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -27,17 +27,6 @@ const COMPARE_PERF  = 'https://www.compare-school-performance.service.gov.uk';
 const FIN_BENCH     = 'https://financial-benchmarking-and-insights-tool.education.gov.uk';
 const POSTCODES_IO  = 'https://api.postcodes.io/postcodes';
 
-// ─── HTML entity decoder ──────────────────────────────────────────────────────
-
-function decodeHTMLEntities(str) {
-  return (str ?? '')
-    .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(parseInt(d, 10)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)))
-    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"').replace(/&apos;/g, '\'').replace(/&#39;/g, '\'')
-    .replace(/&nbsp;/g, ' ');
-}
-
 // ─── Logging ──────────────────────────────────────────────────────────────────
 //
 // Two tiers:
@@ -677,7 +666,7 @@ export async function lookupSchoolURN(name, locationHints = []) {
     if (!linkMatch) continue;
 
     const urn      = linkMatch[1];
-    const tileName = decodeHTMLEntities(linkMatch[2].trim());
+    const tileName = linkMatch[2].trim();
 
     // Phase / type from the DL: <dt>Phase / type:</dt><dd>Secondary, Independent schools</dd>
     const ptMatch     = tile.match(/Phase\s*\/\s*type[^<]*<\/dt>\s*<dd[^>]*>([\s\S]*?)<\/dd>/i);
@@ -730,7 +719,7 @@ export async function lookupSchoolURN(name, locationHints = []) {
           const tile = tileMatch[1];
           const linkMatch = tile.match(/href="\/Establishments\/Establishment\/Details\/(\d{5,7})[^"]*"[^>]*>\s*([^<]+?)\s*<\/a>/);
           if (!linkMatch) continue;
-          const urn = linkMatch[1]; const tileName = decodeHTMLEntities(linkMatch[2].trim());
+          const urn = linkMatch[1]; const tileName = linkMatch[2].trim();
           const ptMatch = tile.match(/Phase\s*\/\s*type[^<]*<\/dt>\s*<dd[^>]*>([\s\S]*?)<\/dd>/i);
           const phaseTypeRaw = ptMatch ? ptMatch[1].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : null;
           const parts = phaseTypeRaw ? phaseTypeRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
@@ -786,7 +775,7 @@ export async function lookupSchoolURN(name, locationHints = []) {
             const urn = linkMatch[1];
             if (seenUrns.has(urn)) continue;
             seenUrns.add(urn);
-            const tileName = decodeHTMLEntities(linkMatch[2].trim());
+            const tileName = linkMatch[2].trim();
             const ptMatch = tile.match(/Phase\s*\/\s*type[^<]*<\/dt>\s*<dd[^>]*>([\s\S]*?)<\/dd>/i);
             const phaseTypeRaw = ptMatch ? ptMatch[1].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : null;
             const parts = phaseTypeRaw ? phaseTypeRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
@@ -2468,22 +2457,6 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
 
   const v = (code) => allRows.find(r => r.variable === code)?.value ?? null;
 
-  // Variant finder — discovers gendered/FSM/EAL/prior-year breakdowns
-  const findVar = (base) => {
-    const r = { all: v(base) };
-    for (const [s, k] of [['_BOYS','boys'],['_GIRLS','girls'],['_FSM6CLA1A','dis'],['_NFSM6CLA1A','ndis'],['_EAL','eal'],['_PREV','prev'],['_PREV2','prev2'],['_24','py24'],['_23','py23']]) {
-      const val = v(base + s); if (val != null) r[k] = val;
-    }
-    if (base.startsWith('PT')) {
-      const t = base.slice(2);
-      if (!r.boys) { const bv = v('PB' + t); if (bv != null) r.boys = bv; }
-      if (!r.girls) { const gv = v('PG' + t); if (gv != null) r.girls = gv; }
-    }
-    if (!r.eal && /BASICS/.test(base)) { const ev = v(base.replace('BASICS', 'BASICSEAL')); if (ev != null) r.eal = ev; }
-    if (!r.eal && /EBACC/.test(base)) { const ev = v(base.replace('EBACC', 'EBACCEAL')); if (ev != null) r.eal = ev; }
-    return r;
-  };
-
   // DfE uses 0, 0%, 0.0% as suppression markers for small cohorts.
   const suppressed = (val) => {
     if (val == null) return true;
@@ -2557,7 +2530,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
   const KS4_TOPICS = [
     {
       heading: 'Attainment 8',
-      cols: 'abgd',
+      cols: 'all',
       rows: [
         { label: 'Attainment 8 score', var: 'ATT8SCR', eng: String(nat4.ATT8SCR) },
       ],
@@ -2569,9 +2542,7 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
         { label: 'English element', var: 'ATT8SCRENG' },
         { label: 'Maths element', var: 'ATT8SCRMAT' },
         { label: 'EBacc element', var: 'ATT8SCREBAC' },
-        { label: 'Open element (total)', var: 'ATT8SCROPEN' },
-        { label: 'Open — GCSE only', var: 'ATT8SCROPENG' },
-        { label: 'Open — non-GCSE', var: 'ATT8SCROPENNG' },
+        { label: 'Open element', var: 'ATT8SCROPEN' },
       ],
     },
     {
@@ -2583,21 +2554,21 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     },
     {
       heading: 'Grade 5+ English & Maths',
-      cols: 'abgd',
+      cols: 'all',
       rows: [
         { label: '% grade 5+ English & maths', var: 'PTL2BASICS_95', eng: nat4.PTL2BASICS_95 + '%' },
       ],
     },
     {
       heading: 'Grade 4+ English & Maths',
-      cols: 'abgd',
+      cols: 'all',
       rows: [
         { label: '% grade 4+ English & maths', var: 'PTL2BASICS_94', eng: nat4.PTL2BASICS_94 + '%' },
       ],
     },
     {
       heading: 'EBacc entry',
-      cols: 'abgd',
+      cols: 'all',
       rows: [
         { label: '% entering EBacc', var: 'PTEBACC_E_PTQ_EE', eng: nat4.PTEBACC_E_PTQ_EE + '%' },
       ],
@@ -2615,40 +2586,11 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
     },
     {
       heading: 'EBacc achievement',
-      cols: 'abgd',
+      cols: 'all',
       rows: [
         { label: '% EBacc 5+', var: 'PTEBACC_95' },
         { label: '% EBacc 4+', var: 'PTEBACC_94', eng: nat4.PTEBACC_94 + '%' },
         { label: 'EBacc APS', var: 'EBACCAPS' },
-      ],
-    },
-    {
-      heading: 'EBacc subject achievement (% of entered pupils)',
-      cols: 'all',
-      rows: [
-        { label: 'English 9-4', var: 'PTEBACENG_94' },
-        { label: 'English 9-5', var: 'PTEBACENG_95' },
-        { label: 'Maths 9-4', var: 'PTEBACMAT_94' },
-        { label: 'Maths 9-5', var: 'PTEBACMAT_95' },
-        { label: 'Science 9-4', var: 'PTEBAC2SCI_94' },
-        { label: 'Science 9-5', var: 'PTEBAC2SCI_95' },
-        { label: 'Humanities 9-4', var: 'PTEBACHUM_94' },
-        { label: 'Humanities 9-5', var: 'PTEBACHUM_95' },
-        { label: 'Languages 9-4', var: 'PTEBACLAN_94' },
-        { label: 'Languages 9-5', var: 'PTEBACLAN_95' },
-      ],
-    },
-    {
-      heading: 'KS4 destinations (2022/23 leavers)',
-      cols: 'all',
-      rows: [
-        { label: '% sustained education or employment', var: 'OVERALL_DESTPER' },
-        { label: '% in education', var: 'EDUCATIONPER' },
-        { label: '% sixth form college', var: 'SIXTH_COLPER' },
-        { label: '% further education', var: 'FEPER' },
-        { label: '% apprenticeships', var: 'APPRENPER' },
-        { label: '% employment', var: 'EMPLOYMENTPER' },
-        { label: '% not sustained', var: 'NOT_SUSTAINEDPER' },
       ],
     },
   ];
@@ -2660,10 +2602,8 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
       rows: [
         { label: 'Total 16–18 students', var: 'TALLPUP_1618' },
         { label: 'A-level students', var: 'TALLPUP_ALEV_1618' },
-        { label: 'A-level entries', var: 'ENTRIES_ALEV' },
         { label: 'Average A-level grade', var: 'TALLPPEGRD_ALEV_1618', eng: nat5.AVG_GRADE ?? 'B-' },
         { label: 'Average A-level points', var: 'TALLPPE_ALEV_1618', eng: nat5.AVG_PTS ? String(nat5.AVG_PTS) : '35' },
-        { label: 'Average grade (all academic)', var: 'TALLPPEGRD_ACAD_1618' },
         { label: 'Best 3 A-levels — grade', var: 'TB3PTSE_GRD' },
         { label: 'Best 3 A-levels — points', var: 'TB3PTSE' },
       ],
@@ -2687,44 +2627,14 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
       ],
     },
     {
-      heading: 'Retention',
-      cols: 'all',
-      rows: [
-        { label: '% retained to end of course', var: 'PT_RETAINED_ALEV_RET' },
-        { label: '% retained to 2nd year', var: 'PT_RETAINED_ACAD_2NDYR' },
-        { label: '% retained (disadvantaged)', var: 'PT_RETAINED_ACAD_RET_DIS' },
-      ],
-    },
-    {
-      heading: 'Level 3 destinations (A-level cohort)',
-      cols: 'all',
-      rows: [
-        { label: '% sustained education or employment', var: 'L3_OVERALLPER' },
-        { label: '% higher education', var: 'L3_HEPER' },
-        { label: '% employment', var: 'L3_EMPLOYMENTPER' },
-        { label: '% apprenticeships', var: 'L3_APPRENPER' },
-        { label: '% further education', var: 'L3_FEPER' },
-        { label: '% not sustained', var: 'L3_NOT_SUSTAINEDPER' },
-      ],
-    },
-    {
-      heading: 'Disadvantaged progression gap',
-      cols: 'all',
-      rows: [
-        { label: '% progressed (disadvantaged)', var: 'DIS_PROGRESSED' },
-        { label: '% progressed (all)', var: 'ALL_PROGRESSED' },
-        { label: '% HE (disadvantaged)', var: 'DIS_HE' },
-        { label: '% HE (all)', var: 'ALL_HE' },
-        { label: '% top third HE (disadvantaged)', var: 'DIS_TOP3RD' },
-        { label: '% top third HE (all)', var: 'ALL_TOP3RD' },
-      ],
-    },
-    {
-      heading: 'Facilitating subjects',
+      heading: 'Facilitating subjects & destinations',
       cols: 'all',
       rows: [
         { label: '% AAB in ≥2 facilitating subjects', var: 'PTAAB_2FAC' },
         { label: '% achieving advanced maths', var: 'L3M_PER' },
+        { label: '% retained to end of course', var: 'PT_RETAINED_ALEV_RET' },
+        { label: '% to higher education', var: 'TOT_HEPER' },
+        { label: '% to any sustained destination', var: 'ALL_PROGRESSED' },
       ],
     },
   ];
@@ -2766,39 +2676,49 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
 
       const cells = [row.label];
 
-      const vars = findVar(row.var);
-      const push = (v) => cells.push(v != null ? c(v) : '—');
-
       if (showAll) {
-        let cell = c(vars.all);
+        let cell = c(val);
         if (row.ciLo && row.ciHi) {
           const lo = v(row.ciLo), hi = v(row.ciHi);
-          if (lo != null && hi != null) cell += ' (CI: ' + lo + ' to ' + hi + ')';
+          if (lo != null && hi != null) cell += ` (CI: ${lo} to ${hi})`;
         }
         cells.push(cell);
       }
-      if (showB)   push(vars.boys);
-      if (showG)   push(vars.girls);
-      if (showD)   push(vars.dis);
-      if (showEal) push(vars.eal);
-      if (showLa)  cells.push('—');
-      if (showEng) cells.push(row.eng ?? '—');
-
-      if (cells.slice(1).some(cell => cell !== '—')) {
-        lines.push('| ' + cells.join(' | ') + ' |');
+      if (showB) {
+        const bvar = row.var + '_BOYS';
+        if (!bvar || bvar === row.var + '_BOYS') cells.push(c(v(row.var.replace('_95','_95').replace('_94','_94') + '_BOYS') || v(row.var + '_BOYS')));
+      }
+      // Simpler: just show All pupils for the main metric, other columns as "—"
+      // This avoids complex suffix-mangling. For a data-driven approach, we
+      // detect gendered/FSM variants by naming convention.
+      if (showB) {
+        // Try common gender suffixes
+        const bVal = v(row.var + '_BOYS') ?? v(row.var.replace(/ALL$/, 'B')) ?? v(row.var.replace('SCR', 'SCR_BOYS'));
+        cells.push(c(bVal));
+      }
+      if (showG) {
+        const gVal = v(row.var + '_GIRLS') ?? v(row.var.replace(/ALL$/, 'G')) ?? v(row.var.replace('SCR', 'SCR_GIRLS'));
+        cells.push(c(gVal));
+      }
+      if (showD) {
+        const dVal = v(row.var + '_FSM6CLA1A') ?? v(row.var.replace('ALL', 'FSM6CLA1A'));
+        cells.push(c(dVal));
+      }
+      if (showEal) {
+        const eVal = v(row.var + '_EAL') ?? v(row.var.replace('ALL', 'EAL'));
+        cells.push(c(eVal));
+      }
+      if (showLa) {
+        // Map to laPerf key
+        cells.push('—');
+      }
+      if (showEng) {
+        cells.push(row.eng ?? '—');
       }
 
-      // Prior-year comparator
-      if (vars.prev != null && !suppressed(vars.prev)) {
-        const pyCells = [row.label + ' (prior year)'];
-        if (showAll) pyCells.push(c(vars.prev));
-        if (showB)   pyCells.push('—');
-        if (showG)   pyCells.push('—');
-        if (showD)   pyCells.push('—');
-        if (showEal) pyCells.push('—');
-        if (showLa)  pyCells.push('—');
-        if (showEng) pyCells.push('—');
-        lines.push('| ' + pyCells.join(' | ') + ' |');
+      // Only add row if it has any non-dash value beyond the label
+      if (cells.slice(1).some(cell => cell !== '—')) {
+        lines.push('| ' + cells.join(' | ') + ' |');
       }
     }
   }
@@ -3346,7 +3266,7 @@ export async function fetchGovDataForPrompt(question, branch, apiKey, baseUrl, m
       // Bundled local data (zero-latency — no HTTP)
       const schoolEthnicity = urn ? getSchoolEthnicity(urn) : null;
 
-      return { input: name, identity, ofsted, performance, financial, area, laPerf, schoolEthnicity, giasDetails, fees: feesResult };
+      return { input: name, identity, ofsted, performance, financial, area, laPerf, schoolEthnicity, giasDetails };
     })
   );
 
@@ -3400,14 +3320,14 @@ export function computeFlags(school) {
   const allRows = Object.values(performance ?? {}).flat();
   const vv = (code) => allRows.find(r => r.variable === code)?.value ?? null;
 
-  // A2 — Ofsted/ISI overall grade
+  // A2 — Ofsted overall grade
   const overall = (ofsted?.overall ?? '').toLowerCase();
-  if (/outstanding|exceptional|excellent/i.test(overall))              flags['A2. Ofsted Inspection Grades'] = 'green';
-  else if (/requires improvement|inadequate|unsatisfactory|sound/i.test(overall)) flags['A2. Ofsted Inspection Grades'] = 'red';
+  if (/outstanding|exceptional/i.test(overall))              flags['A2. Ofsted Inspection Grades'] = 'green';
+  else if (/requires improvement|inadequate/i.test(overall)) flags['A2. Ofsted Inspection Grades'] = 'red';
 
-  // A3 — improvement requirements: content present = red, none + top grade = green
-  if (ofsted?.nextSteps || ofsted?.recommendations)  flags['A3. What the School Needs to Improve'] = 'red';
-  else if (/outstanding|exceptional|excellent/i.test(overall))  flags['A3. What the School Needs to Improve'] = 'green';
+  // A3 — improvement requirements: content present = red, Outstanding + none = green
+  if (ofsted?.nextSteps)                  flags['A3. What the School Needs to Improve'] = 'red';
+  else if (/outstanding/i.test(overall))  flags['A3. What the School Needs to Improve'] = 'green';
 
   // A4 — pupil census: high FSM or EHC
   const fsmPct = parseFloat(vv('PNUMFSMEVER') ?? '');
@@ -3490,13 +3410,7 @@ export function renderPartA(school, flags = {}) {
     .flatMap(([, rows]) => rows);
   const v  = (code) => allRows.find(r => r.variable === code)?.value ?? null;
   const lv = (code) => performance?.L?.find(r => r.variable === code)?.value ?? null;
-  // DfE uses 0%, 0.0%, 0.00% as suppression markers.
-  const d  = (val) => {
-    if (val == null) return '—';
-    const s = String(val).trim();
-    if (s === '0%' || s === '0.0%' || s === '0.00%') return '—';
-    return s;
-  };
+  const d  = (val)  => (val != null ? String(val) : '—');
 
   const sections = [];
 
@@ -3666,29 +3580,27 @@ export function renderPartA(school, flags = {}) {
     const senK = v('PSENELK');
     const senE = v('PSENELSE');
 
-    const sup = (val) => { const s = String(val ?? '').trim(); return s === '0%' || s === '0.0%' || s === '0.00%' || s === '0'; };
     const lines = [
       '| Metric | School | National avg |',
       '|---|---:|---:|',
     ];
-    if (nor && !sup(nor))  lines.push(`| Pupils on roll | ${nor} | ~280 primary / ~1,000 secondary |`);
-    if (fsm && !sup(fsm))  lines.push(`| Free School Meals (FSM) eligible — last 6 years | ${fsm} | ~25% primary / ~20% secondary |`);
-    if (eal && !sup(eal))  lines.push(`| English as Additional Language (EAL) pupils | ${eal} | — |`);
-    if (senK && !sup(senK)) lines.push(`| Special Educational Needs (SEN) support | ${senK} | ~13% |`);
-    if (senE && !sup(senE)) lines.push(`| Education, Health and Care (EHC) plans | ${senE} | ~4.5% |`);
+    if (nor)  lines.push(`| Pupils on roll | ${nor} | ~280 primary / ~1,000 secondary |`);
+    if (fsm)  lines.push(`| Free School Meals (FSM) eligible — last 6 years | ${fsm} | ~25% primary / ~20% secondary |`);
+    if (eal)  lines.push(`| English as Additional Language (EAL) pupils | ${eal} | — |`);
+    if (senK) lines.push(`| Special Educational Needs (SEN) support | ${senK} | ~13% |`);
+    if (senE) lines.push(`| Education, Health and Care (EHC) plans | ${senE} | ~4.5% |`);
 
-    if (schoolEthnicity && !Object.values(schoolEthnicity).every(v => v === 0 || v === '0' || v === '0%')) {
+    if (schoolEthnicity) {
       lines.push('');
       lines.push('| Ethnic group | % of pupils |');
       lines.push('|---|---:|');
-      const eth = schoolEthnicity;
-      if (eth.w  && eth.w  !== 0) lines.push(`| White | ${eth.w}% |`);
-      if (eth.m  && eth.m  !== 0) lines.push(`| Mixed | ${eth.m}% |`);
-      if (eth.a  && eth.a  !== 0) lines.push(`| Asian | ${eth.a}% |`);
-      if (eth.b  && eth.b  !== 0) lines.push(`| Black | ${eth.b}% |`);
-      if (eth.c  && eth.c  !== 0) lines.push(`| Chinese | ${eth.c}% |`);
-      if (eth.o  && eth.o  !== 0) lines.push(`| Other | ${eth.o}% |`);
-      if (eth.ns && eth.ns !== 0) lines.push(`| Not stated | ${eth.ns}% |`);
+      if (schoolEthnicity.w  != null) lines.push(`| White | ${schoolEthnicity.w}% |`);
+      if (schoolEthnicity.m  != null) lines.push(`| Mixed | ${schoolEthnicity.m}% |`);
+      if (schoolEthnicity.a  != null) lines.push(`| Asian | ${schoolEthnicity.a}% |`);
+      if (schoolEthnicity.b  != null) lines.push(`| Black | ${schoolEthnicity.b}% |`);
+      if (schoolEthnicity.c  != null) lines.push(`| Chinese | ${schoolEthnicity.c}% |`);
+      if (schoolEthnicity.o  != null) lines.push(`| Other | ${schoolEthnicity.o}% |`);
+      if (schoolEthnicity.ns != null) lines.push(`| Not stated | ${schoolEthnicity.ns}% |`);
     }
 
     sections.push({ heading: 'A4. Pupil Census', body: lines.join('\n'), flag: flags['A4. Pupil Census'] ?? 'none' });
@@ -3725,28 +3637,10 @@ export function renderPartA(school, flags = {}) {
   // ────────────────────────────────────────────────────────────────────────────
   {
     let body;
-    if (isIndependent) {
-      const f = school.fees;
-      if (f?.day) {
-        const lines = [
-          '| Metric | Value |',
-          '|---|---:|',
-        ];
-        if (f.day) {
-          const range = f.day.min === f.day.max ? `£${f.day.min.toLocaleString()}` : `£${f.day.min.toLocaleString()} — £${f.day.max.toLocaleString()}`;
-          lines.push(`| Day fees (${f.day.period}) | ${range} |`);
-        }
-        if (f.boarding) {
-          const range = f.boarding.min === f.boarding.max ? `£${f.boarding.min.toLocaleString()}` : `£${f.boarding.min.toLocaleString()} — £${f.boarding.max.toLocaleString()}`;
-          lines.push(`| Boarding fees (${f.boarding.period}) | ${range} |`);
-        }
-        if (f.source) lines.push(`| Source | ${f.source} |`);
-        body = lines.join('\n');
-      } else {
-        body = '_Fee data not retrieved from school website. Check the school site or ISC for current fees._';
-      }
-    } else if (!financial) {
-      body = '_Not retrieved — only available for state-funded schools._';
+    if (isIndependent || !financial) {
+      body = isIndependent
+        ? '_Independent school — FBIT data not published for independent schools._'
+        : '_Not retrieved — only available for state-funded schools._';
     } else {
       const lines = [
         '| Metric | School | Comparator avg |',
@@ -3810,37 +3704,9 @@ export function renderPartA(school, flags = {}) {
     sections.push({ heading: 'A8. Area Profile', body, flag: flags['A8. Area Profile'] ?? 'none' });
   }
 
-  // ────────────────────────────────────────────────────────────────────────────
-  // A9. Parent View
-  // ────────────────────────────────────────────────────────────────────────────
-  {
-    const pv = ofsted?.parentView;
-    if (pv && pv.totalResponses) {
-      const yr = pv.academicYear ? ` (${pv.academicYear})` : '';
-      const lines = [
-        `**Ofsted Parent View${yr} — ${pv.totalResponses} responses**`,
-        '',
-        '| Question | % agree |',
-        '|---|---:|',
-      ];
-      const row = (label, val, threshold) => {
-        if (val == null) return;
-        const flag = threshold && val < threshold ? ' ⚠️' : '';
-        lines.push(`| ${label} | ${val}%${flag} |`);
-      };
-      row('Would recommend this school',       pv.wouldRecommend,  80);
-      row('My child is happy here',            pv.childHappy,      null);
-      row('My child feels safe',               pv.childSafe,       88);
-      row('Pupils are well behaved',           pv.wellBehaved,     null);
-      row('Bullying dealt with well',          pv.bullyingHandled, 70);
-      row('School communicates well',          pv.communication,   null);
-      row('Concerns dealt with properly',      pv.concernsHandled, 75);
-      row('Acts in child\'s best interests',   pv.bestInterests,   null);
-      row('Right support to learn',            pv.rightSupport,    null);
-      row('SEND support',                      pv.sendSupport,     null);
-      sections.push({ heading: 'A9. Parent View', body: lines.join('\n'), flag: 'none' });
-    }
-  }
+  // A9. What It's Like to Be a Pupil is generated entirely by the AI
+  // (Call 2 verdict).  No server placeholder needed — interleaveVerdicts
+  // appends the AI-generated A9 section at the end of Part A.
 
   // Tag the first section with the Part A label so the UI renders the divider
   if (sections.length > 0) sections[0]._partLabel = 'Part A — Official Record';


### PR DESCRIPTION
Restored original multi-table A5 format. Added docs/dfe-data-mapping.md with complete DfE variable mapping and render rules for all school types.