### PR TITLE
feat: add all missing DfE variables — KS2 per-subject, KS5 prior years, sub-cohort

### DIFF
--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-30T10:50:42.082Z",
+    "capturedAt": "2026-04-30T10:55:10.644Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,14 +1123,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 151,
+      "totalTransactions": 128,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,340,000",
+      "medianAllTypes": "£1,140,000",
       "byType": {
-        "Flat / Maisonette": "£1,145,000",
+        "Flat / Maisonette": "£900,000",
         "Semi-detached": "£6,050,000",
-        "Detached": "£4,850,000",
-        "Terraced": "£1,581,500"
+        "Detached": "£4,227,000",
+        "Terraced": "£2,625,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/100065.json
+++ b/functions/research/__tests__/fixtures/100065.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 100065,
     "label": "independent-all-through",
-    "capturedAt": "2026-04-30T09:55:32.264Z",
+    "capturedAt": "2026-04-30T10:50:42.082Z",
     "note": "Independent all-through — broadest independent case"
   },
   "input": "University College School",
@@ -1123,14 +1123,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 137,
+      "totalTransactions": 151,
       "postcodesQueried": 100,
-      "medianAllTypes": "£1,100,000",
+      "medianAllTypes": "£1,340,000",
       "byType": {
-        "Flat / Maisonette": "£920,000",
+        "Flat / Maisonette": "£1,145,000",
         "Semi-detached": "£6,050,000",
-        "Detached": "£4,227,000",
-        "Terraced": "£2,250,000"
+        "Detached": "£4,850,000",
+        "Terraced": "£1,581,500"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-30T09:55:21.047Z",
+    "capturedAt": "2026-04-30T10:50:31.033Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 79,
+      "totalTransactions": 172,
       "postcodesQueried": 100,
-      "medianAllTypes": "£440,000",
+      "medianAllTypes": "£427,867",
       "byType": {
-        "Terraced": "£440,000",
-        "Flat / Maisonette": "£260,000",
-        "Semi-detached": "£475,000"
+        "Terraced": "£436,000",
+        "Flat / Maisonette": "£240,000",
+        "Semi-detached": "£470,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/102055.json
+++ b/functions/research/__tests__/fixtures/102055.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 102055,
     "label": "state-secondary-sixth",
-    "capturedAt": "2026-04-30T10:50:31.033Z",
+    "capturedAt": "2026-04-30T10:55:00.180Z",
     "note": "KS4 + KS5 — grammar with sixth form"
   },
   "input": "The Latymer School",
@@ -3687,13 +3687,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 172,
+      "totalTransactions": 68,
       "postcodesQueried": 100,
-      "medianAllTypes": "£427,867",
+      "medianAllTypes": "£390,000",
       "byType": {
-        "Terraced": "£436,000",
+        "Terraced": "£407,000",
         "Flat / Maisonette": "£240,000",
-        "Semi-detached": "£470,000"
+        "Semi-detached": "£461,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-30T09:54:45.364Z",
+    "capturedAt": "2026-04-30T10:49:56.390Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 208,
+      "totalTransactions": 248,
       "postcodesQueried": 100,
-      "medianAllTypes": "£430,000",
+      "medianAllTypes": "£435,000",
       "byType": {
-        "Semi-detached": "£496,500",
-        "Terraced": "£405,000",
-        "Flat / Maisonette": "£242,000",
-        "Detached": "£525,000"
+        "Semi-detached": "£500,000",
+        "Terraced": "£420,000",
+        "Flat / Maisonette": "£260,000",
+        "Detached": "£545,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/124987.json
+++ b/functions/research/__tests__/fixtures/124987.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 124987,
     "label": "state-infant",
-    "capturedAt": "2026-04-30T10:49:56.390Z",
+    "capturedAt": "2026-04-30T10:54:26.339Z",
     "note": "KS1 only — no KS2/KS4/KS5 data expected"
   },
   "input": "Earlswood Infant and Nursery School",
@@ -298,14 +298,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 248,
+      "totalTransactions": 302,
       "postcodesQueried": 100,
-      "medianAllTypes": "£435,000",
+      "medianAllTypes": "£420,000",
       "byType": {
-        "Semi-detached": "£500,000",
-        "Terraced": "£420,000",
-        "Flat / Maisonette": "£260,000",
-        "Detached": "£545,000"
+        "Terraced": "£410,000",
+        "Semi-detached": "£487,500",
+        "Flat / Maisonette": "£250,000",
+        "Detached": "£550,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-30T09:54:53.955Z",
+    "capturedAt": "2026-04-30T10:50:04.849Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,14 +918,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 222,
+      "totalTransactions": 219,
       "postcodesQueried": 100,
-      "medianAllTypes": "£460,000",
+      "medianAllTypes": "£415,000",
       "byType": {
-        "Terraced": "£480,000",
-        "Semi-detached": "£535,000",
-        "Detached": "£890,000",
-        "Flat / Maisonette": "£266,000"
+        "Semi-detached": "£500,000",
+        "Terraced": "£405,000",
+        "Detached": "£600,000",
+        "Flat / Maisonette": "£270,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125068.json
+++ b/functions/research/__tests__/fixtures/125068.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125068,
     "label": "state-junior",
-    "capturedAt": "2026-04-30T10:50:04.849Z",
+    "capturedAt": "2026-04-30T10:54:34.368Z",
     "note": "KS2 only — no KS1 or KS4"
   },
   "input": "Earlswood Junior School",
@@ -918,13 +918,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 219,
+      "totalTransactions": 176,
       "postcodesQueried": 100,
-      "medianAllTypes": "£415,000",
+      "medianAllTypes": "£460,000",
       "byType": {
-        "Semi-detached": "£500,000",
-        "Terraced": "£405,000",
-        "Detached": "£600,000",
+        "Semi-detached": "£523,750",
+        "Terraced": "£423,000",
+        "Detached": "£610,000",
         "Flat / Maisonette": "£270,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-30T09:55:24.733Z",
+    "capturedAt": "2026-04-30T10:50:34.939Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,14 +170,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 156,
+      "totalTransactions": 182,
       "postcodesQueried": 100,
-      "medianAllTypes": "£345,000",
+      "medianAllTypes": "£360,000",
       "byType": {
         "Flat / Maisonette": "£290,000",
-        "Terraced": "£610,000",
-        "Detached": "£1,150,000",
-        "Semi-detached": "£760,000"
+        "Terraced": "£570,000",
+        "Detached": "£1,040,000",
+        "Semi-detached": "£785,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125357.json
+++ b/functions/research/__tests__/fixtures/125357.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125357,
     "label": "independent-primary",
-    "capturedAt": "2026-04-30T10:50:34.939Z",
+    "capturedAt": "2026-04-30T10:55:03.640Z",
     "note": "Independent — no Ofsted, no DfE performance; ISI expected"
   },
   "input": "Micklefield School",
@@ -170,13 +170,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 182,
+      "totalTransactions": 159,
       "postcodesQueried": 100,
-      "medianAllTypes": "£360,000",
+      "medianAllTypes": "£355,000",
       "byType": {
         "Flat / Maisonette": "£290,000",
-        "Terraced": "£570,000",
-        "Detached": "£1,040,000",
+        "Terraced": "£580,000",
+        "Detached": "£980,000",
         "Semi-detached": "£785,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-30T09:55:28.470Z",
+    "capturedAt": "2026-04-30T10:50:38.419Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,13 +1110,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 82,
+      "totalTransactions": 135,
       "postcodesQueried": 74,
-      "medianAllTypes": "£750,000",
+      "medianAllTypes": "£740,000",
       "byType": {
         "Flat / Maisonette": "£340,000",
-        "Detached": "£989,668",
-        "Semi-detached": "£699,950"
+        "Detached": "£990,000",
+        "Semi-detached": "£680,000",
+        "Terraced": "£625,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/125427.json
+++ b/functions/research/__tests__/fixtures/125427.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 125427,
     "label": "independent-secondary",
-    "capturedAt": "2026-04-30T10:50:38.419Z",
+    "capturedAt": "2026-04-30T10:55:07.020Z",
     "note": "Independent secondary — fees, ISI, no DfE data"
   },
   "input": "Caterham School",
@@ -1110,14 +1110,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 135,
+      "totalTransactions": 77,
       "postcodesQueried": 74,
-      "medianAllTypes": "£740,000",
+      "medianAllTypes": "£735,000",
       "byType": {
-        "Flat / Maisonette": "£340,000",
-        "Detached": "£990,000",
-        "Semi-detached": "£680,000",
-        "Terraced": "£625,000"
+        "Flat / Maisonette": "£312,500",
+        "Detached": "£910,000",
+        "Semi-detached": "£680,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-30T10:50:12.447Z",
+    "capturedAt": "2026-04-30T10:54:42.348Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,13 +981,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 167,
+      "totalTransactions": 171,
       "postcodesQueried": 100,
-      "medianAllTypes": "£513,000",
+      "medianAllTypes": "£525,000",
       "byType": {
-        "Flat / Maisonette": "£450,000",
-        "Terraced": "£690,000",
-        "Semi-detached": "£675,000"
+        "Flat / Maisonette": "£430,000",
+        "Terraced": "£705,000",
+        "Semi-detached": "£665,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/137648.json
+++ b/functions/research/__tests__/fixtures/137648.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 137648,
     "label": "state-primary",
-    "capturedAt": "2026-04-30T09:55:02.252Z",
+    "capturedAt": "2026-04-30T10:50:12.447Z",
     "note": "KS1 + KS2 — largest data set for primary"
   },
   "input": "Redriff Primary",
@@ -981,12 +981,12 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 240,
+      "totalTransactions": 167,
       "postcodesQueried": 100,
-      "medianAllTypes": "£520,000",
+      "medianAllTypes": "£513,000",
       "byType": {
-        "Flat / Maisonette": "£470,000",
-        "Terraced": "£700,000",
+        "Flat / Maisonette": "£450,000",
+        "Terraced": "£690,000",
         "Semi-detached": "£675,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-30T10:50:26.464Z",
+    "capturedAt": "2026-04-30T10:54:56.326Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",

--- a/functions/research/__tests__/fixtures/145005.json
+++ b/functions/research/__tests__/fixtures/145005.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145005,
     "label": "state-sixth-form",
-    "capturedAt": "2026-04-30T09:55:17.143Z",
+    "capturedAt": "2026-04-30T10:50:26.464Z",
     "note": "KS5 only — no KS2 or KS4"
   },
   "input": "Reigate College",

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-30T09:55:07.663Z",
+    "capturedAt": "2026-04-30T10:50:17.012Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,14 +1927,14 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 257,
+      "totalTransactions": 197,
       "postcodesQueried": 100,
-      "medianAllTypes": "£455,000",
+      "medianAllTypes": "£450,000",
       "byType": {
-        "Semi-detached": "£480,500",
-        "Terraced": "£440,000",
+        "Semi-detached": "£475,000",
+        "Terraced": "£445,000",
         "Flat / Maisonette": "£250,000",
-        "Detached": "£805,000"
+        "Detached": "£850,000"
       },
       "source": "HM Land Registry Price Paid Data"
     },

--- a/functions/research/__tests__/fixtures/145217.json
+++ b/functions/research/__tests__/fixtures/145217.json
@@ -2,7 +2,7 @@
   "_meta": {
     "urn": 145217,
     "label": "state-secondary",
-    "capturedAt": "2026-04-30T10:50:17.012Z",
+    "capturedAt": "2026-04-30T10:54:46.279Z",
     "note": "KS4 only — Attainment 8, Progress 8, EBacc"
   },
   "input": "Reigate School",
@@ -1927,13 +1927,13 @@
     "pricePaid": {
       "radiusM": 800,
       "yearsBack": 5,
-      "totalTransactions": 197,
+      "totalTransactions": 231,
       "postcodesQueried": 100,
-      "medianAllTypes": "£450,000",
+      "medianAllTypes": "£445,000",
       "byType": {
-        "Semi-detached": "£475,000",
-        "Terraced": "£445,000",
-        "Flat / Maisonette": "£250,000",
+        "Semi-detached": "£480,000",
+        "Terraced": "£450,000",
+        "Flat / Maisonette": "£255,000",
         "Detached": "£850,000"
       },
       "source": "HM Land Registry Price Paid Data"

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-30T10:50:42.083Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-30T10:55:10.645Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -60,6 +60,28 @@
 | % AAB in ≥2 facilitating subjects | 54.6% |
 | % achieving advanced maths | 54.7% |
 
+**KS5 prior years — A-level grade trend**
+| Metric | All pupils |
+|---:|---:|
+| Average grade 2025 | A |
+| Average grade 2024 | A |
+| Average grade 2023 | A- |
+| Average grade 2022 | A+ |
+
+**KS5 prior years — A-level points trend**
+| Metric | All pupils |
+|---:|---:|
+| Average points 2025 | 48.87 |
+| Average points 2024 | 48.91 |
+| Average points 2023 | 47.18 |
+| Average points 2022 | 51.67 |
+
+**KS5 prior years — progress trend**
+| Metric | All pupils |
+|---:|---:|
+| VA score 2025 | 0.2 |
+| VA score 2024 | 0.3 |
+
 ### Financial Benchmarking (FBIT)
 - _Not retrieved_
 
@@ -115,7 +137,7 @@ pupils in Years 7   and 8.
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 151 sales, 5yr): median £1,340,000 · by type: Flat / Maisonette £1,145,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £1,581,500
+- House prices (~800m, 128 sales, 5yr): median £1,140,000 · by type: Flat / Maisonette £900,000, Semi-detached £6,050,000, Detached £4,227,000, Terraced £2,625,000
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/100065.slim.md
+++ b/functions/research/__tests__/snapshots/100065.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-all-through · URN 100065 · captured 2026-04-30T09:55:32.264Z -->
+<!-- independent-all-through · URN 100065 · captured 2026-04-30T10:50:42.083Z -->
 
 ---
 ## Pre-Fetched Government Data — University College School
@@ -115,7 +115,7 @@ pupils in Years 7   and 8.
 - Geography codes: LSOA E01000879 · MSOA E02000169
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 2/10
 - Household income (MSOA): mean gross £87,100 (Census 2021 era) · net £46,300 (ONS 2018) · after housing £38,700
-- House prices (~800m, 137 sales, 5yr): median £1,100,000 · by type: Flat / Maisonette £920,000, Semi-detached £6,050,000, Detached £4,227,000, Terraced £2,250,000
+- House prices (~800m, 151 sales, 5yr): median £1,340,000 · by type: Flat / Maisonette £1,145,000, Semi-detached £6,050,000, Detached £4,850,000, Terraced £1,581,500
 - Ethnicity (LSOA, Census 2021): White 75% · Asian 12% · Mixed 5% · Other 5% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 66% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 56% · routine/manual 7%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T10:50:31.034Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T10:55:00.181Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -92,6 +92,28 @@
 | % to higher education | 71% |
 | % to any sustained destination | 96% |
 
+**KS5 prior years — A-level grade trend**
+| Metric | All pupils |
+|---:|---:|
+| Average grade 2025 | A- |
+| Average grade 2024 | A- |
+| Average grade 2023 | A- |
+| Average grade 2022 | A- |
+
+**KS5 prior years — A-level points trend**
+| Metric | All pupils |
+|---:|---:|
+| Average points 2025 | 47.33 |
+| Average points 2024 | 47.28 |
+| Average points 2023 | 45.75 |
+| Average points 2022 | 48.15 |
+
+**KS5 prior years — progress trend**
+| Metric | All pupils |
+|---:|---:|
+| VA score 2025 | -0.03 |
+| VA score 2024 | 0.01 |
+
 ### Financial Benchmarking (FBIT)
 - In-year balance: £340,889
 - Revenue reserve: £371,909
@@ -138,7 +160,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 172 sales, 5yr): median £427,867 · by type: Terraced £436,000, Flat / Maisonette £240,000, Semi-detached £470,000
+- House prices (~800m, 68 sales, 5yr): median £390,000 · by type: Terraced £407,000, Flat / Maisonette £240,000, Semi-detached £461,000
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/102055.slim.md
+++ b/functions/research/__tests__/snapshots/102055.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T09:55:21.048Z -->
+<!-- state-secondary-sixth · URN 102055 · captured 2026-04-30T10:50:31.034Z -->
 
 ---
 ## Pre-Fetched Government Data — The Latymer School
@@ -138,7 +138,7 @@ Pupils feel safe, are well cared for and happy at school. Pupils of all ages get
 - Geography codes: LSOA E01001461 · MSOA E02000303
 - Deprivation (IMD 2025): decile **1/10** · weaker sub-domains: Income 1/10, Employment 1/10, Education, Skills & Training 1/10, Health & Disability 3/10, Crime 2/10, Barriers to Housing & Services 1/10, Living Environment 2/10
 - Household income (MSOA): mean gross £41,300 (Census 2021 era) · net £32,700 (ONS 2018) · after housing £27,800
-- House prices (~800m, 79 sales, 5yr): median £440,000 · by type: Terraced £440,000, Flat / Maisonette £260,000, Semi-detached £475,000
+- House prices (~800m, 172 sales, 5yr): median £427,867 · by type: Terraced £436,000, Flat / Maisonette £240,000, Semi-detached £470,000
 - Ethnicity (LSOA, Census 2021): White 40% · Black 30% · Other 15% · Asian 11% · Mixed 4%
 - Qualifications (OA, Census 2021): level 4+ 25% · no qualifications 34%
 - Occupation (OA, Census 2021): professional/managerial 19% · routine/manual 35%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-30T10:49:56.390Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-30T10:54:26.339Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -51,7 +51,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 248 sales, 5yr): median £435,000 · by type: Semi-detached £500,000, Terraced £420,000, Flat / Maisonette £260,000, Detached £545,000
+- House prices (~800m, 302 sales, 5yr): median £420,000 · by type: Terraced £410,000, Semi-detached £487,500, Flat / Maisonette £250,000, Detached £550,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/124987.slim.md
+++ b/functions/research/__tests__/snapshots/124987.slim.md
@@ -1,4 +1,4 @@
-<!-- state-infant · URN 124987 · captured 2026-04-30T09:54:45.366Z -->
+<!-- state-infant · URN 124987 · captured 2026-04-30T10:49:56.390Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Infant and Nursery School
@@ -51,7 +51,7 @@ Pupils eagerly anticipate coming to this school. Sights are set high for pupils,
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 208 sales, 5yr): median £430,000 · by type: Semi-detached £496,500, Terraced £405,000, Flat / Maisonette £242,000, Detached £525,000
+- House prices (~800m, 248 sales, 5yr): median £435,000 · by type: Semi-detached £500,000, Terraced £420,000, Flat / Maisonette £260,000, Detached £545,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 59% · no qualifications 7%
 - Occupation (OA, Census 2021): professional/managerial 60% · routine/manual 17%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-30T10:50:04.850Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-30T10:54:34.369Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -70,7 +70,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 219 sales, 5yr): median £415,000 · by type: Semi-detached £500,000, Terraced £405,000, Detached £600,000, Flat / Maisonette £270,000
+- House prices (~800m, 176 sales, 5yr): median £460,000 · by type: Semi-detached £523,750, Terraced £423,000, Detached £610,000, Flat / Maisonette £270,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125068.slim.md
+++ b/functions/research/__tests__/snapshots/125068.slim.md
@@ -1,4 +1,4 @@
-<!-- state-junior · URN 125068 · captured 2026-04-30T09:54:53.956Z -->
+<!-- state-junior · URN 125068 · captured 2026-04-30T10:50:04.850Z -->
 
 ---
 ## Pre-Fetched Government Data — Earlswood Junior School
@@ -24,6 +24,23 @@
 | Reading — average scaled score | 109 |
 | Maths — average scaled score | 106 |
 | GPS — average scaled score | 105 |
+
+**Per-subject attainment — % expected standard**
+| Metric | All pupils |
+|---:|---:|
+| Reading | 88% |
+| Writing (TA) | 76% |
+| Maths | 89% |
+| GPS | 79% |
+| Science (TA) | 91% |
+
+**Per-subject attainment — % higher standard**
+| Metric | All pupils |
+|---:|---:|
+| Reading | 51% |
+| Writing (TA) | 20% |
+| Maths | 30% |
+| GPS | 28% |
 
 ### Financial Benchmarking (FBIT)
 - _Not retrieved_
@@ -53,7 +70,7 @@ Pupils behave well here. They know what is expected of them. This is …_(trunca
 - Geography codes: LSOA E01030573 · MSOA E02006388
 - Deprivation (IMD 2025): decile **9/10** · weaker sub-domains: Living Environment 4/10
 - Household income (MSOA): mean gross £62,300 (Census 2021 era) · net £41,600 (ONS 2018) · after housing £35,600
-- House prices (~800m, 222 sales, 5yr): median £460,000 · by type: Terraced £480,000, Semi-detached £535,000, Detached £890,000, Flat / Maisonette £266,000
+- House prices (~800m, 219 sales, 5yr): median £415,000 · by type: Semi-detached £500,000, Terraced £405,000, Detached £600,000, Flat / Maisonette £270,000
 - Ethnicity (LSOA, Census 2021): White 85% · Asian 9% · Mixed 3% · Black 2% · Other 0%
 - Qualifications (OA, Census 2021): level 4+ 42% · no qualifications 13%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 20%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-30T10:50:34.940Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-30T10:55:03.641Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -64,7 +64,7 @@ for themselves how to explore and deepen their own learning equally strongly acr
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 182 sales, 5yr): median £360,000 · by type: Flat / Maisonette £290,000, Terraced £570,000, Detached £1,040,000, Semi-detached £785,000
+- House prices (~800m, 159 sales, 5yr): median £355,000 · by type: Flat / Maisonette £290,000, Terraced £580,000, Detached £980,000, Semi-detached £785,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125357.slim.md
+++ b/functions/research/__tests__/snapshots/125357.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-primary · URN 125357 · captured 2026-04-30T09:55:24.734Z -->
+<!-- independent-primary · URN 125357 · captured 2026-04-30T10:50:34.940Z -->
 
 ---
 ## Pre-Fetched Government Data — Micklefield School
@@ -64,7 +64,7 @@ for themselves how to explore and deepen their own learning equally strongly acr
 - Geography codes: LSOA E01030627 · MSOA E02006383
 - Deprivation (IMD 2025): decile **10/10** (all sub-domains ≥ 7)
 - Household income (MSOA): mean gross £73,300 (Census 2021 era) · net £41,100 (ONS 2018) · after housing £34,700
-- House prices (~800m, 156 sales, 5yr): median £345,000 · by type: Flat / Maisonette £290,000, Terraced £610,000, Detached £1,150,000, Semi-detached £760,000
+- House prices (~800m, 182 sales, 5yr): median £360,000 · by type: Flat / Maisonette £290,000, Terraced £570,000, Detached £1,040,000, Semi-detached £785,000
 - Ethnicity (LSOA, Census 2021): White 87% · Asian 5% · Mixed 4% · Other 2% · Black 2%
 - Qualifications (OA, Census 2021): level 4+ 48% · no qualifications 9%
 - Occupation (OA, Census 2021): professional/managerial 47% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-30T09:55:28.472Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-30T10:50:38.421Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -270,7 +270,7 @@ development.
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 82 sales, 5yr): median £750,000 · by type: Flat / Maisonette £340,000, Detached £989,668, Semi-detached £699,950
+- House prices (~800m, 135 sales, 5yr): median £740,000 · by type: Flat / Maisonette £340,000, Detached £990,000, Semi-detached £680,000, Terraced £625,000
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/125427.slim.md
+++ b/functions/research/__tests__/snapshots/125427.slim.md
@@ -1,4 +1,4 @@
-<!-- independent-secondary · URN 125427 · captured 2026-04-30T10:50:38.421Z -->
+<!-- independent-secondary · URN 125427 · captured 2026-04-30T10:55:07.021Z -->
 
 ---
 ## Pre-Fetched Government Data — Caterham School
@@ -57,6 +57,28 @@
 |---:|---:|
 | % AAB in ≥2 facilitating subjects | 49.0% |
 | % achieving advanced maths | 50.6% |
+
+**KS5 prior years — A-level grade trend**
+| Metric | All pupils |
+|---:|---:|
+| Average grade 2025 | A- |
+| Average grade 2024 | A |
+| Average grade 2023 | A- |
+| Average grade 2022 | A |
+
+**KS5 prior years — A-level points trend**
+| Metric | All pupils |
+|---:|---:|
+| Average points 2025 | 48.16 |
+| Average points 2024 | 48.8 |
+| Average points 2023 | 45.85 |
+| Average points 2022 | 49.3 |
+
+**KS5 prior years — progress trend**
+| Metric | All pupils |
+|---:|---:|
+| VA score 2025 | 0.26 |
+| VA score 2024 | 0.3 |
 
 ### Financial Benchmarking (FBIT)
 - _Not retrieved_
@@ -270,7 +292,7 @@ development.
 - Geography codes: LSOA E01030828 · MSOA E02006431
 - Deprivation (IMD 2025): decile **10/10** · weaker sub-domains: Barriers to Housing & Services 4/10
 - Household income (MSOA): mean gross £63,200 (Census 2021 era) · net £38,600 (ONS 2018) · after housing £32,900
-- House prices (~800m, 135 sales, 5yr): median £740,000 · by type: Flat / Maisonette £340,000, Detached £990,000, Semi-detached £680,000, Terraced £625,000
+- House prices (~800m, 77 sales, 5yr): median £735,000 · by type: Flat / Maisonette £312,500, Detached £910,000, Semi-detached £680,000
 - Ethnicity (LSOA, Census 2021): White 84% · Asian 8% · Mixed 4% · Black 3% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 41% · no qualifications 8%
 - Occupation (OA, Census 2021): professional/managerial 42% · routine/manual 11%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-30T10:50:12.448Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-30T10:54:42.348Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -89,7 +89,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 167 sales, 5yr): median £513,000 · by type: Flat / Maisonette £450,000, Terraced £690,000, Semi-detached £675,000
+- House prices (~800m, 171 sales, 5yr): median £525,000 · by type: Flat / Maisonette £430,000, Terraced £705,000, Semi-detached £665,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/137648.slim.md
+++ b/functions/research/__tests__/snapshots/137648.slim.md
@@ -1,4 +1,4 @@
-<!-- state-primary · URN 137648 · captured 2026-04-30T09:55:02.254Z -->
+<!-- state-primary · URN 137648 · captured 2026-04-30T10:50:12.448Z -->
 
 ---
 ## Pre-Fetched Government Data — Redriff Primary, City of London Academy
@@ -24,6 +24,23 @@
 | Reading — average scaled score | 110 |
 | Maths — average scaled score | 109 |
 | GPS — average scaled score | 112 |
+
+**Per-subject attainment — % expected standard**
+| Metric | All pupils |
+|---:|---:|
+| Reading | 92% |
+| Writing (TA) | 91% |
+| Maths | 91% |
+| GPS | 89% |
+| Science (TA) | 91% |
+
+**Per-subject attainment — % higher standard**
+| Metric | All pupils |
+|---:|---:|
+| Reading | 65% |
+| Writing (TA) | 43% |
+| Maths | 49% |
+| GPS | 68% |
 
 ### Financial Benchmarking (FBIT)
 - In-year balance: -£378,130
@@ -72,7 +89,7 @@ Staff present information clearly to pupils. They provide pupils with different 
 - Geography codes: LSOA E01004056 · MSOA E02000814
 - Deprivation (IMD 2025): decile **6/10** · weaker sub-domains: Income 5/10, Employment 6/10, Health & Disability 4/10, Crime 5/10, Living Environment 6/10
 - Household income (MSOA): mean gross £77,200 (Census 2021 era) · net £51,500 (ONS 2018) · after housing £43,600
-- House prices (~800m, 240 sales, 5yr): median £520,000 · by type: Flat / Maisonette £470,000, Terraced £700,000, Semi-detached £675,000
+- House prices (~800m, 167 sales, 5yr): median £513,000 · by type: Flat / Maisonette £450,000, Terraced £690,000, Semi-detached £675,000
 - Ethnicity (LSOA, Census 2021): White 64% · Asian 14% · Black 11% · Mixed 6% · Other 5%
 - Qualifications (OA, Census 2021): level 4+ 43% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 34% · routine/manual 25%

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-30T10:50:26.465Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-30T10:54:56.327Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College
@@ -45,6 +45,42 @@
 | % retained to end of course | 97.6% |
 | % to higher education | 48% |
 | % to any sustained destination | 69% |
+
+**KS5 prior years — A-level grade trend**
+| Metric | All pupils |
+|---:|---:|
+| Average grade 2025 | B- |
+| Average grade 2024 | B- |
+| Average grade 2023 | B- |
+| Average grade 2022 | B |
+
+**KS5 prior years — A-level points trend**
+| Metric | All pupils |
+|---:|---:|
+| Average points 2025 | 37.7 |
+| Average points 2024 | 37.38 |
+| Average points 2023 | 36.75 |
+| Average points 2022 | 40.38 |
+
+**KS5 prior years — progress trend**
+| Metric | All pupils |
+|---:|---:|
+| VA score 2025 | 0.13 |
+| VA score 2024 | 0.14 |
+
+**Tech levels & T-levels**
+| Metric | All pupils |
+|---:|---:|
+| T-level students | 145 |
+| T-level average grade | Dist- |
+| T-level average points | 30.68 |
+
+**Applied general**
+| Metric | All pupils |
+|---:|---:|
+| Applied general students | 732 |
+| Applied general average grade | Dist- |
+| Applied general average points | 31.78 |
 
 ### Financial Benchmarking (FBIT)
 - In-year balance: £823,000

--- a/functions/research/__tests__/snapshots/145005.slim.md
+++ b/functions/research/__tests__/snapshots/145005.slim.md
@@ -1,4 +1,4 @@
-<!-- state-sixth-form · URN 145005 · captured 2026-04-30T09:55:17.144Z -->
+<!-- state-sixth-form · URN 145005 · captured 2026-04-30T10:50:26.465Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate College

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-30T10:50:17.013Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-30T10:54:46.280Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -104,7 +104,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 197 sales, 5yr): median £450,000 · by type: Semi-detached £475,000, Terraced £445,000, Flat / Maisonette £250,000, Detached £850,000
+- House prices (~800m, 231 sales, 5yr): median £445,000 · by type: Semi-detached £480,000, Terraced £450,000, Flat / Maisonette £255,000, Detached £850,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/__tests__/snapshots/145217.slim.md
+++ b/functions/research/__tests__/snapshots/145217.slim.md
@@ -1,4 +1,4 @@
-<!-- state-secondary · URN 145217 · captured 2026-04-30T09:55:07.664Z -->
+<!-- state-secondary · URN 145217 · captured 2026-04-30T10:50:17.013Z -->
 
 ---
 ## Pre-Fetched Government Data — Reigate School
@@ -104,7 +104,7 @@ Pupils’ conduct is excellent in lessons and …_(truncated — full PDF: https
 - Geography codes: LSOA E01030594 · MSOA E02006387
 - Deprivation (IMD 2025): decile **7/10** · weaker sub-domains: Income 5/10, Employment 6/10
 - Household income (MSOA): mean gross £60,100 (Census 2021 era) · net £43,200 (ONS 2018) · after housing £36,800
-- House prices (~800m, 257 sales, 5yr): median £455,000 · by type: Semi-detached £480,500, Terraced £440,000, Flat / Maisonette £250,000, Detached £805,000
+- House prices (~800m, 197 sales, 5yr): median £450,000 · by type: Semi-detached £475,000, Terraced £445,000, Flat / Maisonette £250,000, Detached £850,000
 - Ethnicity (LSOA, Census 2021): White 90% · Mixed 4% · Asian 3% · Black 2% · Other 1%
 - Qualifications (OA, Census 2021): level 4+ 30% · no qualifications 23%
 - Occupation (OA, Census 2021): professional/managerial 32% · routine/manual 34%

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -2658,6 +2658,57 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
         { label: '% to any sustained destination', var: 'ALL_PROGRESSED' },
       ],
     },
+    {
+      heading: 'KS5 prior years — A-level grade trend',
+      cols: 'all',
+      rows: [
+        { label: 'Average grade 2025', var: 'TALLPPEGRD_ALEV_1618' },
+        { label: 'Average grade 2024', var: 'TALLPPEGRD_ALEV_1618_24' },
+        { label: 'Average grade 2023', var: 'TALLPPEGRD_ALEV_1618_23' },
+        { label: 'Average grade 2022', var: 'TALLPPEGRD_ALEV_1618_22' },
+      ],
+    },
+    {
+      heading: 'KS5 prior years — A-level points trend',
+      cols: 'all',
+      rows: [
+        { label: 'Average points 2025', var: 'TALLPPE_ALEV_1618' },
+        { label: 'Average points 2024', var: 'TALLPPE_ALEV_1618_24' },
+        { label: 'Average points 2023', var: 'TALLPPE_ALEV_1618_23' },
+        { label: 'Average points 2022', var: 'TALLPPE_ALEV_1618_22' },
+      ],
+    },
+    {
+      heading: 'KS5 prior years — progress trend',
+      cols: 'all',
+      rows: [
+        { label: 'VA score 2025', var: 'VA_INS_ALEV' },
+        { label: 'VA score 2024', var: 'VA_INS_ALEV_24' },
+        { label: 'VA score 2023', var: 'VA_INS_ALEV_23' },
+        { label: 'VA score 2022', var: 'VA_INS_ALEV_22' },
+      ],
+    },
+    {
+      heading: 'Tech levels & T-levels',
+      cols: 'all',
+      rows: [
+        { label: 'Tech cert students', var: 'TALLPUP_TECHCERT' },
+        { label: 'Tech cert average grade', var: 'TALLPPEGRD_TECHCERT' },
+        { label: 'Tech cert average points', var: 'TALLPPE_TECHCERT' },
+        { label: 'T-level students', var: 'TALLPUP_TLEV' },
+        { label: 'T-level average grade', var: 'TALLPPEGRD_TLEV' },
+        { label: 'T-level average points', var: 'TALLPPE_TLEV' },
+      ],
+    },
+    {
+      heading: 'Applied general',
+      cols: 'all',
+      rows: [
+        { label: 'Applied general students', var: 'TALLPUP_AGEN' },
+        { label: 'Applied general average grade', var: 'TALLPPEGRD_AGEN' },
+        { label: 'Applied general average points', var: 'TALLPPE_AGEN' },
+      ],
+    },
   ];
 
   // ── Table renderer ────────────────────────────────────────────────────────

--- a/functions/research/govuk.js
+++ b/functions/research/govuk.js
@@ -2517,6 +2517,27 @@ function fmtAcademicResultsSlim(perf, phase, fallbackNor = null, laPerf = null, 
       ],
     },
     {
+      heading: 'Per-subject attainment — % expected standard',
+      cols: 'all',
+      rows: [
+        { label: 'Reading', var: 'PTREAD_EXP' },
+        { label: 'Writing (TA)', var: 'PTWRITTA_EXP' },
+        { label: 'Maths', var: 'PTMAT_EXP' },
+        { label: 'GPS', var: 'PTGPS_EXP' },
+        { label: 'Science (TA)', var: 'PTSCITA_EXP' },
+      ],
+    },
+    {
+      heading: 'Per-subject attainment — % higher standard',
+      cols: 'all',
+      rows: [
+        { label: 'Reading', var: 'PTREAD_HIGH' },
+        { label: 'Writing (TA)', var: 'PTWRITTA_HIGH' },
+        { label: 'Maths', var: 'PTMAT_HIGH' },
+        { label: 'GPS', var: 'PTGPS_HIGH' },
+      ],
+    },
+    {
       heading: 'Progress (KS1 to KS2)',
       cols: 'all',
       rows: [


### PR DESCRIPTION
Show everything the DfE publishes. Added KS2 per-subject attainment, KS5 grade/points/progress trends, tech levels, T-levels, applied general. Each topic auto-hides if data not present.